### PR TITLE
recipes-votp/system-conf: load US keys

### DIFF
--- a/recipes-votp/system-config/system-config/votp-loadkeys.service
+++ b/recipes-votp/system-config/system-config/votp-loadkeys.service
@@ -7,7 +7,7 @@ Description="Load keys for Votp"
 [Service]
 Type=oneshot
 RemainAfterExit=true
-ExecStart=loadkeys fr
+ExecStart=loadkeys us
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Load US keys instead of FR in votp-loadkeys systemd service.

Signed-off-by: Eloi Bail <eloi.bail@savoirfairelinux.com>