### PR TITLE
linux/linux-mainline-rt.inc: add elfutils-native to kernel DEPENDS

### DIFF
--- a/recipes-kernel/linux/linux-mainline-rt.inc
+++ b/recipes-kernel/linux/linux-mainline-rt.inc
@@ -17,7 +17,7 @@ do_firmware_path () {
 addtask firmware_path before do_build after do_configure
 
 # Kernel build process dependencies
-DEPENDS += "bc-native bison-native openssl-native util-linux-native xz-native rsync-native"
+DEPENDS += "bc-native bison-native openssl-native util-linux-native xz-native rsync-native elfutils-native"
 
 KBRANCH ?= "v4.19.106-rt44"
 KCONFIG_MODE="--alldefconfig"


### PR DESCRIPTION
Corrects the following error which occurs during kernel compilation

error: Cannot generate ORC metadata for CONFIG_UNWINDER_ORC=y, please
install libelf-dev, libelf-devel or elfutils-libelf-devel

Signed-off-by: Peter Smith <salerio@gmail.com>