### PR TITLE
fix bad Yocto overrides syntax

### DIFF
--- a/recipes-elastic/elastic-beats/elastic-beats-metricbeat_%.bbappend
+++ b/recipes-elastic/elastic-beats/elastic-beats-metricbeat_%.bbappend
@@ -1,14 +1,14 @@
-FILESEXTRAPATHS:prepend :="${THISDIR}/files:"
+FILESEXTRAPATHS_prepend :="${THISDIR}/files:"
 
 inherit systemd
 SYSTEMD_AUTO_ENABLE = "enable"
 
-SRC_URI:append = " file://metricbeat.service"
-SRC_URI:append = " file://system.yml"
-SYSTEMD_SERVICE:${PN} = "metricbeat.service"
-FILES:${PN} += "${systemd_system_unitdir}/metricbeat.service"
+SRC_URI_append = " file://metricbeat.service"
+SRC_URI_append = " file://system.yml"
+SYSTEMD_SERVICE_${PN} = "metricbeat.service"
+FILES_${PN} += "${systemd_system_unitdir}/metricbeat.service"
 
-do_install:append() {
+do_install_append() {
   install -d ${D}${sysconfdir}/${GO_PACKAGE}/modules.d
   install -m 0644 ${WORKDIR}/system.yml ${D}${sysconfdir}/${GO_PACKAGE}/modules.d/system.yml
   install -d ${D}${systemd_system_unitdir}

--- a/recipes-extended/go/go-1.16.8.inc
+++ b/recipes-extended/go/go-1.16.8.inc
@@ -2,7 +2,7 @@ require go-common.inc
 
 GO_BASEVERSION = "1.16"
 PV = "1.16.8"
-FILESEXTRAPATHS:prepend := "${FILE_DIRNAME}/go-${GO_BASEVERSION}:"
+FILESEXTRAPATHS_prepend := "${FILE_DIRNAME}/go-${GO_BASEVERSION}:"
 
 LIC_FILES_CHKSUM = "file://LICENSE;md5=5d4950ecb7b26d2c5e4e7b4e0dd74707"
 

--- a/recipes-extended/go/go-common.inc
+++ b/recipes-extended/go/go-common.inc
@@ -37,6 +37,6 @@ export GO386 ?= "${TARGET_GO386}"
 export GOMIPS ?= "${TARGET_GOMIPS}"
 export GOROOT_FINAL ?= "${libdir}/go"
 
-do_compile:prepend() {
+do_compile_prepend() {
 	BUILD_CC=${BUILD_CC}
 }

--- a/recipes-extended/go/go-native_1.16.8.bb
+++ b/recipes-extended/go/go-native_1.16.8.bb
@@ -5,7 +5,7 @@ require go-${PV}.inc
 
 inherit native
 
-SRC_URI:append = " https://dl.google.com/go/go1.4-bootstrap-20171003.tar.gz;name=bootstrap;subdir=go1.4"
+SRC_URI_append = " https://dl.google.com/go/go1.4-bootstrap-20171003.tar.gz;name=bootstrap;subdir=go1.4"
 SRC_URI[bootstrap.sha256sum] = "f4ff5b5eb3a3cae1c993723f3eab519c5bae18866b5e5f96fe1102f0cb5c3e52"
 
 export GOOS = "${BUILD_GOOS}"

--- a/recipes-extended/go/go-runtime.inc
+++ b/recipes-extended/go/go-runtime.inc
@@ -1,5 +1,5 @@
 DEPENDS = "virtual/${TUNE_PKGARCH}-go go-native"
-DEPENDS:class-nativesdk = "virtual/${TARGET_PREFIX}go-crosssdk"
+DEPENDS_class-nativesdk = "virtual/${TARGET_PREFIX}go-crosssdk"
 PROVIDES = "virtual/${TARGET_PREFIX}go-runtime"
 
 export CGO_CFLAGS = "${CFLAGS}"
@@ -12,10 +12,9 @@ GO_EXTLDFLAGS ?= "${HOST_CC_ARCH}${TOOLCHAIN_OPTIONS} ${LDFLAGS}"
 GO_SHLIB_LDFLAGS ?= '-ldflags="--linkmode=external -extldflags '${GO_EXTLDFLAGS}'"'
 
 do_configure() {
-	:
 }
 
-do_configure:libc-musl() {
+do_configure_libc-musl() {
 	rm -f ${S}/src/runtime/race/*.syso
 }
 
@@ -55,9 +54,9 @@ do_install() {
 
 }
 
-ALLOW_EMPTY:${PN} = "1"
-FILES:${PN} = "${libdir}/go/pkg/${TARGET_GOTUPLE}_dynlink/*${SOLIBSDEV}"
-FILES:${PN}-dev = "${libdir}/go/src ${libdir}/go/pkg/include \
+ALLOW_EMPTY_${PN} = "1"
+FILES_${PN} = "${libdir}/go/pkg/${TARGET_GOTUPLE}_dynlink/*${SOLIBSDEV}"
+FILES_${PN}-dev = "${libdir}/go/src ${libdir}/go/pkg/include \
                    ${libdir}/go/pkg/${TARGET_GOTUPLE}_dynlink/*.shlibname \
                    ${libdir}/go/pkg/${TARGET_GOTUPLE}_dynlink/*/*.shlibname \
                    ${libdir}/go/pkg/${TARGET_GOTUPLE}_dynlink/*/*/*.shlibname \
@@ -73,12 +72,12 @@ FILES:${PN}-dev = "${libdir}/go/src ${libdir}/go/pkg/include \
                    ${libdir}/go/pkg/${TARGET_GOTUPLE}_dynlink/*/*/*/*/*/*.a \
                    ${libdir}/go/pkg/${TARGET_GOTUPLE}_dynlink/*/*/*/*/*/*/*.a \
 "
-FILES:${PN}-staticdev = "${libdir}/go/pkg/${TARGET_GOTUPLE}"
+FILES_${PN}-staticdev = "${libdir}/go/pkg/${TARGET_GOTUPLE}"
 
 # Go sources include some scripts and pre-built binaries for
 # multiple architectures.  The static .a files for dynamically-linked
 # runtime are also required in -dev.
-INSANE_SKIP:${PN}-dev = "staticdev file-rdeps arch"
+INSANE_SKIP_${PN}-dev = "staticdev file-rdeps arch"
 
 INHIBIT_PACKAGE_STRIP = "1"
 INHIBIT_PACKAGE_DEBUG_SPLIT = "1"

--- a/recipes-extended/go/go-target.inc
+++ b/recipes-extended/go/go-target.inc
@@ -1,12 +1,12 @@
 DEPENDS = "virtual/${TUNE_PKGARCH}-go go-native"
-DEPENDS:class-nativesdk = "virtual/${TARGET_PREFIX}go-crosssdk go-native"
+DEPENDS_class-nativesdk = "virtual/${TARGET_PREFIX}go-crosssdk go-native"
 
 export GOCACHE = "${B}/.cache"
 GO_LDFLAGS = ""
-GO_LDFLAGS:class-nativesdk = "-linkmode external"
+GO_LDFLAGS_class-nativesdk = "-linkmode external"
 export GO_LDFLAGS
 
-CC:append:class-nativesdk = " ${SECURITY_NOPIE_CFLAGS}"
+CC_append_class-nativesdk = " ${SECURITY_NOPIE_CFLAGS}"
 
 do_configure[noexec] = "1"
 
@@ -38,8 +38,8 @@ do_install() {
 }
 
 PACKAGES = "${PN} ${PN}-dev"
-FILES:${PN} = "${libdir}/go/bin ${libdir}/go/pkg/tool/${TARGET_GOTUPLE} ${bindir}"
-RDEPENDS:${PN} = "go-runtime"
-INSANE_SKIP:${PN} = "ldflags"
+FILES_${PN} = "${libdir}/go/bin ${libdir}/go/pkg/tool/${TARGET_GOTUPLE} ${bindir}"
+RDEPENDS_${PN} = "go-runtime"
+INSANE_SKIP_${PN} = "ldflags"
 
 BBCLASSEXTEND = "nativesdk"


### PR DESCRIPTION
The Yocto overrides syntax like _append or _prepend have changed in latest Yocto version from "_" to ":".

Go and elastic-beats recipes files use the new Yocto overrides syntax but, this syntax is not supported by our Yocto version (Dunfell). Update this file to use the old syntax (using "_").

Signed-off-by: Mathieu Dupré <mathieu.dupre@savoirfairelinux.com>