### PR TITLE
Swupdate bugs

### DIFF
--- a/recipes-votp/system-config/system-config/efi/swupdate_hawkbit.sh
+++ b/recipes-votp/system-config/system-config/efi/swupdate_hawkbit.sh
@@ -30,7 +30,7 @@ fi
 mount "${bootloader_part}" /boot 2>/dev/null
 # The system has been updated
 if [ -f /boot/EFI/BOOT/grubenv ] ; then
-    if ! check_health ; then
+    if ! check-health ; then
         echo "Update tests haves failed" 1>&2
         echo "Rebooting to the last working state..."
         grub-editenv /boot/EFI/BOOT/grubenv set "bootcount=4"

--- a/recipes-votp/system-upgrade/files/switch_bootloader.sh
+++ b/recipes-votp/system-upgrade/files/switch_bootloader.sh
@@ -34,6 +34,22 @@ boot1_order=$(echo "${bootorder}" | \
     grep -n "${boot1}" | \
     cut -d ':' -f 1)
 
+if [ "${boot0_order}" = "" ]; then
+  bootorder=$(echo "${bootorder}" | sed "s/${boot1}/${boot1},${boot0}/")
+  boot0_order=$(echo "${bootorder}" | \
+    tr ',' '\n' | \
+    grep -n "${boot0}" | \
+    cut -d ':' -f 1)
+fi
+
+if [ "${boot1_order}" = "" ]; then
+  bootorder=$(echo "${bootorder}" | sed "s/${boot0}/${boot0},${boot1}/")
+  boot1_order=$(echo "${bootorder}" | \
+    tr ',' '\n' | \
+    grep -n "${boot1}" | \
+    cut -d ':' -f 1)
+fi
+
 if [ "${boot0_order}" -lt "${boot1_order}" ] ; then
     active_boot="${boot0}"
     passive_boot="${boot1}"


### PR DESCRIPTION
fixes 2 bugs with swupdate:

    switch_bootloader.sh: fix for some UEFI behavior
    Some UEFI firmware tend to remove from the boot order all slots that are
    explicitely disabled (if they are disabled, they have nothing to do in
    the boot order).
    switch_bootloader.sh assume both Seapath slots are present in the boot
    order, but since the UEFI may have removed the disabled slot, this may
    not be the case.
    This fix makes switch_bootloader.sh working even if both slots are not
    in the boot order

    system-config: fix typo in swupdate_hawkbit.sh
    Fix typo in check_health.