### PR TITLE
kernel parameters: disable IPv6

### DIFF
--- a/recipes-bsp/grub/files/votp-monitor/grub-efi.cfg
+++ b/recipes-bsp/grub/files/votp-monitor/grub-efi.cfg
@@ -38,7 +38,7 @@ menuentry 'active_slot' --unrestricted{
     # Convert device to filesystem identifier
     set sys_part=(${disk},${part}${part_num})
     probe --set sys_part_uuid --part-uuid $sys_part
-    linux /bzImage console=ttyS0,115200 console=tty0 root=PARTUUID=$sys_part_uuid rootwait rootfstype=ext4 systemd.unified_cgroup_hierarchy=0 audit=0 efi=runtime slab_nomerge pti=on slub_debug=ZF init=/sbin/init.sh
+    linux /bzImage console=ttyS0,115200 console=tty0 root=PARTUUID=$sys_part_uuid rootwait rootfstype=ext4 systemd.unified_cgroup_hierarchy=0 audit=0 efi=runtime slab_nomerge pti=on slub_debug=ZF init=/sbin/init.sh ipv6.disable=1
 }
 
 

--- a/recipes-bsp/grub/files/votp-no-iommu/grub-efi.cfg
+++ b/recipes-bsp/grub/files/votp-no-iommu/grub-efi.cfg
@@ -38,7 +38,7 @@ menuentry 'active_slot' --unrestricted{
     # Convert device to filesystem identifier
     set sys_part=(${disk},${part}${part_num})
     probe --set sys_part_uuid --part-uuid $sys_part
-    linux /bzImage console=ttyS0,115200 console=tty0 root=PARTUUID=$sys_part_uuid rootwait rootfstype=ext4 systemd.unified_cgroup_hierarchy=0 audit=0 efi=runtime slab_nomerge pti=on slub_debug=ZF init=/sbin/init.sh
+    linux /bzImage console=ttyS0,115200 console=tty0 root=PARTUUID=$sys_part_uuid rootwait rootfstype=ext4 systemd.unified_cgroup_hierarchy=0 audit=0 efi=runtime slab_nomerge pti=on slub_debug=ZF init=/sbin/init.sh ipv6.disable=1
 }
 
 

--- a/recipes-bsp/grub/files/votp-vm/grub-efi.cfg
+++ b/recipes-bsp/grub/files/votp-vm/grub-efi.cfg
@@ -4,5 +4,5 @@ serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
 default=boot
 timeout=0
 menuentry 'boot' --unrestricted{
-linux /bzImage console=ttyS0,115200 console=tty0 root=/dev/vda2 rootwait rootfstype=ext4 systemd.unified_cgroup_hierarchy=0 audit=0 slab_nomerge pti=on slub_debug=ZF
+linux /bzImage console=ttyS0,115200 console=tty0 root=/dev/vda2 rootwait rootfstype=ext4 systemd.unified_cgroup_hierarchy=0 audit=0 slab_nomerge pti=on slub_debug=ZF ipv6.disable=1
 }

--- a/recipes-bsp/grub/files/votp/grub-efi.cfg
+++ b/recipes-bsp/grub/files/votp/grub-efi.cfg
@@ -38,7 +38,7 @@ menuentry 'active_slot' --unrestricted{
     # Convert device to filesystem identifier
     set sys_part=(${disk},${part}${part_num})
     probe --set sys_part_uuid --part-uuid $sys_part
-    linux /bzImage console=ttyS0,115200 console=tty0 root=PARTUUID=$sys_part_uuid rootwait rootfstype=ext4 default_hugepagesz=1G hugepagesz=1G hugepages=7 systemd.unified_cgroup_hierarchy=0 audit=0 isolcpus=2-9 nohz_full=2-9 rcu_nocbs=2-9 efi=runtime slab_nomerge pti=on slub_debug=ZF init=/sbin/init.sh
+    linux /bzImage console=ttyS0,115200 console=tty0 root=PARTUUID=$sys_part_uuid rootwait rootfstype=ext4 default_hugepagesz=1G hugepagesz=1G hugepages=7 systemd.unified_cgroup_hierarchy=0 audit=0 isolcpus=2-9 nohz_full=2-9 rcu_nocbs=2-9 efi=runtime slab_nomerge pti=on slub_debug=ZF init=/sbin/init.sh ipv6.disable=1
 }
 
 

--- a/wic/mkbiosdisk.wks.in
+++ b/wic/mkbiosdisk.wks.in
@@ -9,4 +9,4 @@ part / --source rootfs --ondisk sda --fstype=ext4 --label platform --align 1024 
 part /var/log --size 4096 --ondisk sda --fstype=ext4 --label log --align 1024
 part /mnt/persistent --size 256 --ondisk sda --fstype=ext4 --label persistent --align 1024
 
-bootloader --timeout=0 --append="rootwait rootfstype=ext4 console=ttyS0,115200 console=tty0 default_hugepagesz=1G hugepagesz=1G hugepages=7 systemd.unified_cgroup_hierarchy=0 audit=0 isolcpus=2-5 nohz_full=2-5 rcu_nocbs=2-5 slab_nomerge pti=on slub_debug=ZF init=/sbin/init.sh extra_kernel_parameters_markers"
+bootloader --timeout=0 --append="rootwait rootfstype=ext4 console=ttyS0,115200 console=tty0 default_hugepagesz=1G hugepagesz=1G hugepages=7 systemd.unified_cgroup_hierarchy=0 audit=0 isolcpus=2-5 nohz_full=2-5 rcu_nocbs=2-5 slab_nomerge pti=on slub_debug=ZF init=/sbin/init.sh extra_kernel_parameters_markers ipv6.disable=1"


### PR DESCRIPTION
IPv6 in SEAPATH has not been taken into account and tested. For security
reasons it is better to disable it.
The IPv6 disabling is done in kernel parameters to avoid givin the
possibility de re-enabled at runtime.
The IPv6 can easily be restored if necessary by deleting the kernel
parameter.

Signed-off-by: insatomcat <florent.carli@rte-france.com>