### PR TITLE
recipes-core/systemd: remove default DNS server

### DIFF
--- a/recipes-core/systemd/files/resolved.conf
+++ b/recipes-core/systemd/files/resolved.conf
@@ -1,0 +1,24 @@
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+#
+# Entries in this file show the compile time defaults.
+# You can change settings by editing this file.
+# Defaults can be restored by simply deleting this file.
+#
+# See resolved.conf(5) for details
+
+[Resolve]
+DNS=
+FallbackDNS=
+#Domains=
+#LLMNR=yes
+#MulticastDNS=yes
+#DNSSEC=no
+#DNSOverTLS=no
+#Cache=yes
+#DNSStubListener=yes
+#ReadEtcHosts=yes

--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -7,6 +7,7 @@ SRC_URI_append = " \
     file://basic.conf \
     file://boot-complete.target \
     file://journald.conf \
+    file://resolved.conf \
 "
 PACKAGECONFIG_append = " seccomp"
 do_install_append () {
@@ -22,5 +23,7 @@ do_install_append () {
     install -m 644 ${WORKDIR}/boot-complete.target \
         ${D}/${systemd_unitdir}/system/boot-complete.target
     install -m 0644 ${WORKDIR}/journald.conf \
+        ${D}${sysconfdir}/systemd
+    install -m 0644 ${WORKDIR}/resolved.conf \
         ${D}${sysconfdir}/systemd
 }


### PR DESCRIPTION
By default systemd-resolved, the DNS client use by SEAPATH use Goolge DNS servers is there no DNS server configured by systemd-networkd to always have a DNS server configured.

In SEAPATH the DNS servers configuration is done during the setup step is if during this step no DNS server was provided we condidered it is besause it is wanted and we do not want to failback to Google DNS servers.

Signed-off-by: insatomcat <florent.carli@rte-france.com>