### PR TITLE
Guest image: Add docker

### DIFF
--- a/recipes-core/images/seapath-guest-common.inc
+++ b/recipes-core/images/seapath-guest-common.inc
@@ -13,6 +13,9 @@ IMAGE_INSTALL_append = " \
     syslog-ng-client \
     system-config-security \
 "
+#add docker
+IMAGE_INSTALL += " docker-ce docker-ce-contrib python3-docker-compose"
+
 IMAGE_FSTYPES = "wic.qcow2 wic.vmdk"
 WKS_FILE = "mkefidisk-guest.wks.in"
 


### PR DESCRIPTION
It will be recommended to containerize the workload as much as possible,
the guest image needs to be able to run docker containers since it will
be the "recommended" way of doing things.

Signed-off-by: insatomcat <florent.carli@rte-france.com>