### PR TITLE
pacemaker/glue: add smtp capability

### DIFF
--- a/recipes-cgl/cluster-glue/cluster-glue_%.bbappend
+++ b/recipes-cgl/cluster-glue/cluster-glue_%.bbappend
@@ -1,6 +1,11 @@
 # Copyright (C) 2021, RTE (http://www.rte-france.com)
 # SPDX-License-Identifier: Apache-2.0
 
+#to add hacluster to the msmtp group, so that it can write to msmtp log file
+RDEPENDS_${PN} += "msmtp"
+DEPENDS += "msmtp"
+USERADD_PARAM_${PN}:prepend = " -G msmtp "
+
 do_install_append() {
     for file in $(find ${D}${libdir}/stonith/plugins/external -type f); do
         sed -i "s%${HOSTTOOLS_DIR}/%%g" "${file}"

--- a/recipes-core/images/seapath-host-common-ha.inc
+++ b/recipes-core/images/seapath-host-common-ha.inc
@@ -15,4 +15,5 @@ IMAGE_INSTALL_append = " \
     pacemaker \
     python3-vm-manager \
     resource-agents \
+    mailx \
 "

--- a/recipes-extended/msmtp/msmtp_%.bbappend
+++ b/recipes-extended/msmtp/msmtp_%.bbappend
@@ -1,0 +1,13 @@
+# Copyright (C) 2021, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+
+inherit useradd
+
+USERADD_PACKAGES = "${PN}"
+GROUPADD_PACKAGES = "${PN}"
+GROUPADD_PARAM_${PN} = "-g 2000 msmtp"
+
+do_install:append() {
+  install -d ${D}${sysconfdir}/tmpfiles.d
+  echo "d /var/log/msmtp 0770 hacluster msmtp -" > ${D}${sysconfdir}/tmpfiles.d/msmtp.conf
+}


### PR DESCRIPTION
This commit adds and configure msmtp, to be able to send emails from
seapath

Signed-off-by: insatomcat <florent.carli@rte-france.com>