### PR TITLE
unsafe pam-policy: make feature available for all seapath images

### DIFF
--- a/classes/security/pam-policy.bbclass
+++ b/classes/security/pam-policy.bbclass
@@ -5,8 +5,6 @@
 # Setup and install hardened PAM policy
 #
 
-IMAGE_FEATURES[validitems] += "unsafe-pam-policy"
-
 install_pam_policy() {
     if ${@bb.utils.contains('DISTRO_FEATURES', 'pam', 'true', 'false', d)}; then
         rm --one-file-system -f ${IMAGE_ROOTFS}/etc/pam.d/*

--- a/conf/distro/seapath-common.inc
+++ b/conf/distro/seapath-common.inc
@@ -95,3 +95,6 @@ INHERIT += "security/readonly"
 INHERIT += "overlay"
 
 DISTROOVERRIDES =. "seapath."
+
+IMAGE_FEATURES[validitems] += "unsafe-pam-policy"
+


### PR DESCRIPTION
right now the unsafe-pam policy is available only if using the hardening
is enabled, whichmakes it impossible to build a dbg image (unsafe-pam
enabled) while using "no security" distro feature.
This patch makes it possible by enabling unsafe-pam for all seapath
images.

Signed-off-by: insatomcat <florent.carli@rte-france.com>