### PR TITLE
init.sh: move kernel boot argument to machines

### DIFF
--- a/classes/security/readonly.inc
+++ b/classes/security/readonly.inc
@@ -5,4 +5,3 @@
 
 IMAGE_FEATURES += "read-only-rootfs"
 ROOTFS_RO_UNNEEDED ?= "update-rc.d ${VIRTUAL-RUNTIME_update-alternatives} ${ROOTFS_BOOTSTRAP_INSTALL}"
-APPEND += "init=/sbin/init.sh"

--- a/conf/machine/votp-host.conf
+++ b/conf/machine/votp-host.conf
@@ -7,3 +7,4 @@
 #@DESCRIPTION: Machine configuration for hypervisor compatible with SEAPATH
 
 require conf/machine/votp-machine-common.inc
+APPEND += "init=/sbin/init.sh"

--- a/conf/machine/votp-monitor.conf
+++ b/conf/machine/votp-monitor.conf
@@ -7,3 +7,4 @@
 #@DESCRIPTION: Machine configuration for monitor machines compatible with SEAPATH
 
 require conf/machine/votp-machine-common.inc
+APPEND += "init=/sbin/init.sh"


### PR DESCRIPTION
Right now the init.sh script (used for overlay) is enabled only when the
readonly distro feature is enabled.
This changes allows the overlay to work whether readonly is enabled or
not.

Signed-off-by: insatomcat <florent.carli@rte-france.com>