### PR TITLE
grub-efi: remove extra ipv6.disable and add efi=runtime

### DIFF
--- a/recipes-bsp/grub/files/grub-efi.cfg.in
+++ b/recipes-bsp/grub/files/grub-efi.cfg.in
@@ -34,7 +34,7 @@ menuentry 'active_slot' --unrestricted{
     # Convert device to filesystem identifier
     set sys_part=(${disk},${part}${part_num})
     probe --set sys_part_uuid --part-uuid $sys_part
-    linux /bzImage console=ttyS0,115200 console=tty0 root=PARTUUID=$sys_part_uuid ipv6.disable=1 $kernel_parameters
+    linux /bzImage console=ttyS0,115200 console=tty0 root=PARTUUID=$sys_part_uuid efi=runtime $kernel_parameters
 }
 
 


### PR DESCRIPTION
efi=runtime is needed for efi vars to work in vm.

Signed-off-by: insatomcat <florent.carli@rte-france.com>