### PR TITLE
sw-description: bug in base image name

### DIFF
--- a/recipes-core/images/files/sw-description
+++ b/recipes-core/images/files/sw-description
@@ -4,14 +4,14 @@ software =
 
     images: (
         {
-            filename = "@@IMAGE_BASENAME@@-boot.tar.xz";
+            filename = "@@IMAGE_DEPENDS@@-boot.tar.xz";
             filesystem = "vfat";
             type = "archive";
             device = "/dev/upgradable_bootloader";
             path = "/";
         },
         {
-            filename = "@@IMAGE_BASENAME@@-@@MACHINE@@.tar.xz";
+            filename = "@@IMAGE_DEPENDS@@-@@MACHINE@@.tar.xz";
             filesystem = "ext4";
             type = "archive";
             device = "/dev/upgradable_rootfs";


### PR DESCRIPTION
base the SWU image on the dependant image instead of the current image name

Signed-off-by: insatomcat <florent.carli@rte-france.com>