### PR TITLE
Guest Distro feature: remove overlay

### DIFF
--- a/conf/distro/seapath-guest.conf
+++ b/conf/distro/seapath-guest.conf
@@ -11,3 +11,4 @@ DISTRO_VERSION = "1.0"
 #Remove uneeded features
 DISTRO_FEATURES_remove = "seapath-clustering"
 DISTRO_FEATURES_remove = "seapath-readonly"
+DISTRO_FEATURES_remove = "seapath-overlay"


### PR DESCRIPTION
Overlay is not used in guest image (no persistent partition, etc.)

Signed-off-by: insatomcat <florent.carli@rte-france.com>