### PR TITLE
init.sh: move kernel boot argument to machine (no-iommu)

### DIFF
--- a/conf/machine/votp-no-iommu.conf
+++ b/conf/machine/votp-no-iommu.conf
@@ -8,3 +8,4 @@
 
 require conf/machine/votp-machine-common.inc
 MACHINEOVERRIDES =. "votp-host:"
+APPEND += "init=/sbin/init.sh"


### PR DESCRIPTION
Right now the init.sh script (used for overlay) is enabled only when the
readonly distro feature is enabled.
This changes allows the overlay to work whether readonly is enabled or
not.
A precedent commit already made that changes for host and monitor vm,
this commit is for the no-iommu machine

Signed-off-by: insatomcat <florent.carli@rte-france.com>