### PR TITLE
Ceph recipe: silly typo in parallelisation limiting code

### DIFF
--- a/recipes-extended/ceph/ceph_%.bbappend
+++ b/recipes-extended/ceph/ceph_%.bbappend
@@ -24,7 +24,7 @@ EXTRA_OECMAKE = "-DWITH_MANPAGE=OFF \
 
 def limit_parallel(d):
     import multiprocessing
-    return "-j{}".format(d.getVar("SEAPATH_PARALLEL_MAKE", mutiprocessing.cpu_count()))
+    return "-j{}".format(d.getVar("SEAPATH_PARALLEL_MAKE", multiprocessing.cpu_count()))
 
 PARALLEL_MAKE = "${@limit_parallel(d)}"
 


### PR DESCRIPTION
Signed-off-by: insatomcat <florent.carli@rte-france.com>