### PR TITLE
seapath-dbg-common.inc : add netperf

### DIFF
--- a/recipes-core/images/seapath-dbg-common.inc
+++ b/recipes-core/images/seapath-dbg-common.inc
@@ -4,7 +4,7 @@
 # Monitoring tools
 IMAGE_INSTALL += "htop"
 IMAGE_INSTALL += "console-vm-script curl screen stress-ng rsync sysstat"
-IMAGE_INSTALL += "strace dnf gdb pigz lsof git iperf3"
+IMAGE_INSTALL += "strace dnf gdb pigz lsof git iperf3 netperf"
 
 # Network tools
 IMAGE_INSTALL += "tcpdump inetutils-ping inetutils-ping6"

--- a/recipes-support/netperf/netperf_%.bbappend
+++ b/recipes-support/netperf/netperf_%.bbappend
@@ -1,0 +1,4 @@
+LICENSE_FLAGS = ""
+HOMEPAGE = "http://www.netperf.org/"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://COPYING;md5=a0ab17253e7a3f318da85382c7d5d5d6"


### PR DESCRIPTION
Signed-off-by: watare <aurelien.watare@gmail.com>

Add netperf to measure the latency of the virtual network. More info are available [here](https://www.redhat.com/en/blog/hands-vhost-net-do-or-do-not-there-no-try)

update the license-flag from "non-commercial" to " " as netperf is now in MIT. The recipe is available [here](http://cgit.openembedded.org/meta-openembedded/tree/meta-networking/recipes-support/netperf/netperf_git.bb?h=master)