### PR TITLE
votp-guest : add ptp_kvm support

### DIFF
--- a/recipes-core/images/seapath-guest-common.inc
+++ b/recipes-core/images/seapath-guest-common.inc
@@ -14,6 +14,9 @@ IMAGE_INSTALL_append = " \
     net-snmp-server \
     net-snmp-client \
     net-snmp-dev \
+    ethtool \
+    chrony \
+    chronyc \
 "
 #add docker
 IMAGE_INSTALL += " docker-ce docker-ce-contrib python3-docker-compose"

--- a/recipes-kernel/linux/linux-mainline-rt/ptp_kvm.cfg
+++ b/recipes-kernel/linux/linux-mainline-rt/ptp_kvm.cfg
@@ -1,0 +1,19 @@
+CONFIG_NET_PTP_CLASSIFY=y
+CONFIG_PPS=y
+# CONFIG_PPS_DEBUG is not set
+
+#
+# PPS clients support
+#
+# CONFIG_PPS_CLIENT_KTIMER is not set
+# CONFIG_PPS_CLIENT_LDISC is not set
+# CONFIG_PPS_CLIENT_GPIO is not set
+
+#
+# PPS generators support
+#
+CONFIG_PTP_1588_CLOCK=y
+CONFIG_PTP_1588_CLOCK_KVM=y
+# CONFIG_PTP_1588_CLOCK_IDT82P33 is not set
+# CONFIG_PTP_1588_CLOCK_IDTCM is not set
+# CONFIG_PTP_1588_CLOCK_VMW is not set

--- a/recipes-kernel/linux/linux-mainline-rt_5.15.bb
+++ b/recipes-kernel/linux/linux-mainline-rt_5.15.bb
@@ -14,6 +14,9 @@ SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/rt/linux-stable-rt.git;
         file://megaraid.cfg \
 "
 
+SRC_URI_append_votp-guest = " \
+        file://ptp_kvm.cfg \
+"
 SRC_URI_append_votp-no-iommu = " \
         file://no-iommu.cfg \
 "


### PR DESCRIPTION
Signed-off-by: watare <aurelien.watare@gmail.com>

PTP_KVM is used for high precision time sync between host and guests. It relies on transferring the wall clock and counter value from the host to the guest using a KVM-specific hypercall

this PR add 

- the kernel module ptp_kvm to be able to create a PHC clock 
- chronyd and chronyc to sync the guest with the PHC clock

to the votp-guest

([more detail](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/virtualization_deployment_and_administration_guide/chap-kvm_guest_timing_management))

