### PR TITLE
distro/seapath-host-sb: fix bad include

### DIFF
--- a/conf/distro/seapath-host-sb.conf
+++ b/conf/distro/seapath-host-sb.conf
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Distro based on SEAPATH
-require conf/distro/seapath.conf
+require conf/distro/seapath-host.conf
 
 # Enable UEFI Secureboot
 require conf/distro/include/enable-uefi-secureboot.inc


### PR DESCRIPTION
seapath-host-sb distro is based on seapath-host not seapath.

Signed-off-by: Mathieu Dupré <mathieu.dupre@savoirfairelinux.com>