### PR TITLE
Support UEFI on flash PXE image

### DIFF
--- a/recipes-core/images/seapath-flash-pxe.bb
+++ b/recipes-core/images/seapath-flash-pxe.bb
@@ -10,3 +10,10 @@ INITRAMFS_IMAGE_BUNDLE = "1"
 
 # Set initramfs max size ot 256 MB
 INITRAMFS_MAXSIZE = "262144"
+
+
+# Install EFI tools
+IMAGE_INSTALL_append = " \
+    efitools             \
+    efibootmgr           \
+"

--- a/recipes-votp/flash-script/files/flash.sh
+++ b/recipes-votp/flash-script/files/flash.sh
@@ -92,7 +92,7 @@ else
 fi
 
 # If EFI image create boot entries
-if command -v efibootmgr &> /dev/null ; then
+if command -v efibootmgr &> /dev/null && efibootmgr &> /dev/null ; then
 
     echo "EFI image."
     entry_num=$(efibootmgr | awk '/SEAPATH slot 0/{ gsub("Boot", ""); gsub("*", ""); print $1 }')


### PR DESCRIPTION
Install efitools and efibootmgr in flash PXE image and to keep PXE entry before SEAPATH entries move SEAPATH entries at the end of the boot order.