### PR TITLE
seapath-host-common-virtu: install dpdk-tools

### DIFF
--- a/recipes-core/images/seapath-host-common-virtu.inc
+++ b/recipes-core/images/seapath-host-common-virtu.inc
@@ -3,6 +3,7 @@
 
 # Virtualization
 IMAGE_INSTALL_append = " \
+    dpdk-tools \
     libvirt \
     libvirt-libvirtd \
     libvirt-virsh \

--- a/recipes-extended/dpdk/dpdk_20.%.bbappend
+++ b/recipes-extended/dpdk/dpdk_20.%.bbappend
@@ -1,0 +1,10 @@
+# Copyright (C) 2022, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+
+do_install_append() {
+    install -m 0755 -d ${D}/${sbindir}
+    ln -s ${bindir}/dpdk-devbind.py ${D}/${sbindir}/dpdk-devbind
+
+}
+
+FILES_${PN}-tools += "${sbindir}/dpdk-devbind"


### PR DESCRIPTION
To have dpdk-devbind install dpdk-tools. Create a symlink into /usr/sbin as it was done in the DPDK's recipe in for previous DPDK versions.