### PR TITLE
python3-setup-ovs: add python3-pyyaml RDEPENDS

### DIFF
--- a/recipes-votp/python3-setup-ovs/python3-setup-ovs.bb
+++ b/recipes-votp/python3-setup-ovs/python3-setup-ovs.bb
@@ -5,7 +5,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/.:"
 DESCRIPTION = "A Python3 module to apply an OVS configuration from a JSON file"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
-RDEPENDS_${PN} = "python3 openvswitch"
+RDEPENDS_${PN} = "python3 openvswitch python3-pyyaml"
 SRC_URI = "file://src/"
 S = "${WORKDIR}/src"
 inherit setuptools3


### PR DESCRIPTION
RDEPENDS python3-pyyaml is missing, it only works with cluster's images
because the package is included by crmsh.

Signed-off-by: Thibault Sourdin <thibault.sourdin@savoirfairelinux.com>