### PR TITLE
recipes-core/images/seapath-flash-common: add mkfs command

### DIFF
--- a/recipes-core/images/seapath-flash-common.inc
+++ b/recipes-core/images/seapath-flash-common.inc
@@ -5,6 +5,7 @@ LICENSE = "Apache-2.0"
 require recipes-core/images/core-image-minimal.bb
 IMAGE_INSTALL_append = " \
     bmap-tools \
+    e2fsprogs-mke2fs \
     flash-script \
     python3-json \
     python3-modules \


### PR DESCRIPTION
The mkfs command is needed in some cases to resize partitions after
flashing.

Signed-off-by: Thibault Sourdin <thibault.sourdin@savoirfairelinux.com>