### PR TITLE
images: add efibootmgr to monitor_efi image

### DIFF
--- a/recipes-core/images/seapath-efi-common.inc
+++ b/recipes-core/images/seapath-efi-common.inc
@@ -11,5 +11,3 @@ IMAGE_INSTALL_append = " \
     efibootmgr           \
     cukinia-tests-efi    \
 "
-
-IMAGE_FSTYPES += "tar.gz"

--- a/recipes-core/images/seapath-monitor-efi-image.bb
+++ b/recipes-core/images/seapath-monitor-efi-image.bb
@@ -3,6 +3,7 @@
 
 DESCRIPTION = "A monitor image for Seapath cluster"
 require seapath-common.inc
+require seapath-efi-common.inc
 require seapath-host-common-ha.inc
 require seapath-monitor-common.inc
 require seapath-swupdate-common.inc


### PR DESCRIPTION
In fact add a missing dependency in monitor images that add packages for efi management.

Signed-off-by: Erwann Roussy <erwann.roussy@savoirfairelinux.com>