### PR TITLE
syslog-ng: fix service dependencies

### DIFF
--- a/recipes-support/syslog-ng/files/syslog-ng@.service
+++ b/recipes-support/syslog-ng/files/syslog-ng@.service
@@ -2,6 +2,7 @@
 Description=System Logger Daemon "%i" instance
 Documentation=man:syslog-ng(8)
 Conflicts=emergency.service emergency.target
+After=network-online.target
 After=create-syslog-ng-log-dir.service
 Wants=create-syslog-ng-log-dir.service
 


### PR DESCRIPTION
The syslog-ng service create a socket, so it needs the network to be online and not just created.

Signed-off-by: Erwann Roussy <erwann.roussy@savoirfairelinux.com>