### PR TITLE
linux-mainline-rt: bump to 5.15.92-rt57

### DIFF
--- a/recipes-kernel/linux/linux-mainline-rt_5.15.bb
+++ b/recipes-kernel/linux/linux-mainline-rt_5.15.bb
@@ -4,8 +4,8 @@
 require linux-mainline-rt.inc
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
-LINUX_VERSION = "5.15.36"
-RT_REVISION = "rt41"
+LINUX_VERSION = "5.15.92"
+RT_REVISION = "rt57"
 PV = "${LINUX_VERSION}-${RT_REVISION}"
 KBRANCH = "v${PV}"
 


### PR DESCRIPTION
Signed-off-by: Mathieu Dupré <mathieu.dupre@savoirfairelinux.com>