### PR TITLE
machine/votp-host: fix KVM halt_poll_ns module parameter

### DIFF
--- a/conf/machine/votp-host.conf
+++ b/conf/machine/votp-host.conf
@@ -13,5 +13,5 @@ APPEND += " \
     hugepagesz=1G \
     skew_tick=1 \
     rcutree.kthread_prio=10 \
-    kvm.halt_poll_ns=-1 \
+    kvm.halt_poll_ns=0 \
     "


### PR DESCRIPTION
Change the KVM halt_poll_ns module parameter set by Grub to 0. The previous value -1 is an incorrect value. To disable halt_poll_ns (this is what we want for real-time purpose) we have to set halt_poll_ns to 0.

Change-Id: I7d2f8718b6f1251a2259488c5e9a8d5fa4cdcffe