### PR TITLE
recipes-connectivity/linuxptp: backport linuxptp 3.1.1

### DIFF
--- a/conf/distro/seapath-common.inc
+++ b/conf/distro/seapath-common.inc
@@ -98,3 +98,6 @@ DISTROOVERRIDES =. "seapath."
 
 IMAGE_FEATURES[validitems] += "unsafe-pam-policy"
 
+# Set version of linuxptp to 3.1.1
+PREFERRED_VERSION_libvirt = "3.1.1"
+

--- a/recipes-connectivity/linuxptp/files/ptp4l@.service
+++ b/recipes-connectivity/linuxptp/files/ptp4l@.service
@@ -5,7 +5,7 @@ After=network-online.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/ptp4l -q -m -i %I
+ExecStart=/usr/sbin/ptp4l -q -m -i %I
 
 [Install]
 WantedBy=multi-user.target

--- a/recipes-connectivity/linuxptp/linuxptp/0001-include-string.h-for-strncpy.patch
+++ b/recipes-connectivity/linuxptp/linuxptp/0001-include-string.h-for-strncpy.patch
@@ -1,0 +1,27 @@
+From d49b4fb8063ecd89617587e5ea566cc9da9393ef Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Wed, 31 Aug 2022 19:09:18 -0700
+Subject: [PATCH] include string.h for strncpy()
+
+Upstream-Status: Pending
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ interface.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/interface.c b/interface.c
+index 65bdff0..5228db9 100644
+--- a/interface.c
++++ b/interface.c
+@@ -5,6 +5,7 @@
+  * @note SPDX-License-Identifier: GPL-2.0+
+  */
+ #include <stdlib.h>
++#include <string.h>
+ #include "interface.h"
+ 
+ struct interface {
+-- 
+2.37.3
+

--- a/recipes-connectivity/linuxptp/linuxptp/0001-makefile-use-conditional-assignment-for-KBUILD_OUTPU.patch
+++ b/recipes-connectivity/linuxptp/linuxptp/0001-makefile-use-conditional-assignment-for-KBUILD_OUTPU.patch
@@ -1,0 +1,42 @@
+From dfd38cb29c0768692f886d3ab9158bd2b3132582 Mon Sep 17 00:00:00 2001
+From: Changqing Li <changqing.li@windriver.com>
+Date: Tue, 22 Nov 2022 15:20:48 +0800
+Subject: [PATCH] makefile: use conditional assignment for KBUILD_OUTPUT
+
+Refer [1],from make 4.4, all variables that are marked as export will
+also be passed to the shell started by the shell function. use "=" will
+make KBUILD_OUTPUT always empty for shell function, use "?=" to make
+"export KBUILD_OUTPUT" in enrironment can work.
+
+[snip of 4.4 NEWS]
+* WARNING: Backward-incompatibility!
+   Previously makefile variables marked as export were not exported to commands
+   started by the $(shell ...) function.  Now, all exported variables are
+   exported to $(shell ...).
+[snip]
+
+[1] https://git.savannah.gnu.org/cgit/make.git/tree/NEWS?h=4.4&id=ed493f6c9116cc217b99c2cfa6a95f15803235a2#n74
+
+Upstream-Status: Submitted [linuxptp-devel@lists.sourceforge.net]
+
+Signed-off-by: Changqing Li <changqing.li@windriver.com>
+---
+ makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/makefile b/makefile
+index 529d8a0..3db60fa 100644
+--- a/makefile
++++ b/makefile
+@@ -15,7 +15,7 @@
+ # with this program; if not, write to the Free Software Foundation, Inc.,
+ # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ 
+-KBUILD_OUTPUT =
++KBUILD_OUTPUT ?=
+ 
+ DEBUG	=
+ CC	?= $(CROSS_COMPILE)gcc
+-- 
+2.25.1
+

--- a/recipes-connectivity/linuxptp/linuxptp/Use-cross-cpp-in-incdefs.patch
+++ b/recipes-connectivity/linuxptp/linuxptp/Use-cross-cpp-in-incdefs.patch
@@ -1,0 +1,26 @@
+From 8a4cad5e2f2cbb6a34bdc6e877fe499502b8c4c8 Mon Sep 17 00:00:00 2001
+From: Marcel Ziswiler <marcel.ziswiler@toradex.com>
+Date: Fri, 23 Dec 2016 18:12:29 +0100
+Subject: [PATCH] linuxptp: Use cross cpp in incdefs
+
+Use cross cpp incdefs.sh shell script since we are doing cross compiling
+we need to ensure we use correct setttings from toolchain
+
+Upstream-Status: Inappropriate [OE-Specific]
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+
+ makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/incdefs.sh
++++ b/incdefs.sh
+@@ -27,7 +27,7 @@ user_flags()
+ 	printf " -D_GNU_SOURCE"
+ 
+ 	# Get list of directories searched for header files.
+-	dirs=$(echo "" | ${CROSS_COMPILE}cpp -Wp,-v 2>&1 >/dev/null | grep ^" /")
++	dirs=$(${CPP} -Wp,-v -xc /dev/null 2>&1 >/dev/null | grep ^" /")
+ 
+ 	# Look for clock_adjtime().
+ 	for d in $dirs; do

--- a/recipes-connectivity/linuxptp/linuxptp/build-Allow-CC-and-prefix-to-be-overriden.patch
+++ b/recipes-connectivity/linuxptp/linuxptp/build-Allow-CC-and-prefix-to-be-overriden.patch
@@ -1,0 +1,37 @@
+From af485c638c61fa883212ea424e676fbf90bee594 Mon Sep 17 00:00:00 2001
+From: Otavio Salvador <otavio@ossystems.com.br>
+Date: Tue, 1 Jul 2014 17:37:31 -0300
+Subject: [PATCH] build: Allow CC and prefix to be overriden
+
+Upstream-Status: Pending
+
+Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>
+---
+ makefile |    4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/makefile b/makefile
+index 22e7d0d..809cc8f 100644
+--- a/makefile
++++ b/makefile
+@@ -18,7 +18,7 @@
+ KBUILD_OUTPUT =
+ 
+ DEBUG	=
+-CC	= $(CROSS_COMPILE)gcc
++CC	?= $(CROSS_COMPILE)gcc
+ VER     = -DVER=$(version)
+ CFLAGS	= -Wall $(VER) $(incdefs) $(DEBUG) $(EXTRA_CFLAGS)
+ LDLIBS	= -lm -lrt -pthread $(EXTRA_LDFLAGS)
+@@ -43,7 +43,7 @@ incdefs := $(shell $(srcdir)/incdefs.sh)
+ version := $(shell $(srcdir)/version.sh $(srcdir))
+ VPATH	= $(srcdir)
+ 
+-prefix	= /usr/local
++prefix	?= /usr/local
+ sbindir	= $(prefix)/sbin
+ mandir	= $(prefix)/man
+ man8dir	= $(mandir)/man8
+-- 
+1.7.10.4
+

--- a/recipes-connectivity/linuxptp/linuxptp_%.bbappend
+++ b/recipes-connectivity/linuxptp/linuxptp_%.bbappend
@@ -14,7 +14,6 @@ SRC_URI:append = " \
     file://phc2sys@.service \
 "
 do_install:append() {
-  install -p ${S}/phc_ctl  ${D}${bindir}
   install -d ${D}${systemd_system_unitdir}
   install -m 0644 ${WORKDIR}/ptp4l@.service ${D}${systemd_system_unitdir}/
   install -m 0644 ${WORKDIR}/phc2sys@.service ${D}${systemd_system_unitdir}/

--- a/recipes-connectivity/linuxptp/linuxptp_3.1.1.bb
+++ b/recipes-connectivity/linuxptp/linuxptp_3.1.1.bb
@@ -1,0 +1,33 @@
+DESCRIPTION = "Precision Time Protocol (PTP) according to IEEE standard 1588 for Linux"
+HOMEPAGE = "http://linuxptp.sourceforge.net/"
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
+
+SRC_URI = "http://sourceforge.net/projects/linuxptp/files/v3.1/linuxptp-${PV}.tgz \
+           file://build-Allow-CC-and-prefix-to-be-overriden.patch \
+           file://Use-cross-cpp-in-incdefs.patch \
+           file://0001-include-string.h-for-strncpy.patch \
+           file://0001-makefile-use-conditional-assignment-for-KBUILD_OUTPU.patch \
+           "
+
+UPSTREAM_CHECK_URI = "https://sourceforge.net/projects/linuxptp/files/"
+UPSTREAM_CHECK_REGEX = "(?P<pver>\d+(\.\d+)+)/"
+
+SRC_URI[sha256sum] = "94d6855f9b7f2d8e9b0ca6d384e3fae6226ce6fc012dbad02608bdef3be1c0d9"
+
+EXTRA_OEMAKE = "ARCH=${TARGET_ARCH} EXTRA_CFLAGS='${CFLAGS}' mandir=${mandir}"
+
+export KBUILD_OUTPUT="${RECIPE_SYSROOT}"
+
+do_install() {
+    oe_runmake install DESTDIR=${D} prefix=${prefix}
+
+    # Install example configs from source tree
+    install -d ${D}${docdir}/${PN}
+    cp -R --no-dereference --preserve=mode,links ${S}/configs ${D}${docdir}/${PN}
+}
+
+PACKAGES =+ "${PN}-configs"
+
+FILES:${PN}-configs = "${docdir}"
+FILES:${PN}-doc = "${mandir}"


### PR DESCRIPTION
Backport linuxptp 3.1.1 from Poky master-next: 518d0decd56b8f47f812004b5e7aa094c23014c1

We need this version to have timemaster.