### PR TITLE
distro: replace PREFERRED_VERSION by REQUIRED_VERSION

### DIFF
--- a/conf/distro/seapath-common.inc
+++ b/conf/distro/seapath-common.inc
@@ -34,8 +34,8 @@ DISTRO_FEATURES_append = " kvm"
 # Enable dpdk for openvswitch
 PACKAGECONFIG_append_pn-openvswitch = " dpdk"
 COMPATIBLE_MACHINE_pn-dpdk = "(votp)"
-PREFERRED_VERSION_openvswitch = "2.15%"
-PREFERRED_VERSION_dpdk = "20.11.%"
+REQUIRED_VERSION_openvswitch = "2.15%"
+REQUIRED_VERSION_dpdk = "20.11.%"
 
 # Disable and blacklist busybox
 PREFERRED_PROVIDER_virtual/base-utils = "packagegroup-core-base-utils"
@@ -84,7 +84,7 @@ DISTRO_FEATURES_append = " seapath-overlay"
 DISTRO_FEATURES_append = " seapath-clustering"
 
 # Set version of Libvirt to 6.3.0 (solves GH issue #22)
-PREFERRED_VERSION_libvirt = "6.3.0"
+REQUIRED_VERSION_libvirt = "6.3.0"
 
 # Set persistent /var/log
 VOLATILE_LOG_DIR = "no"
@@ -99,5 +99,5 @@ DISTROOVERRIDES =. "seapath."
 IMAGE_FEATURES[validitems] += "unsafe-pam-policy"
 
 # Set version of linuxptp to 3.1.1
-PREFERRED_VERSION_linuxptp = "3.1.1"
+REQUIRED_VERSION_linuxptp = "3.1.1"
 

--- a/conf/distro/seapath-common.inc
+++ b/conf/distro/seapath-common.inc
@@ -99,5 +99,5 @@ DISTROOVERRIDES =. "seapath."
 IMAGE_FEATURES[validitems] += "unsafe-pam-policy"
 
 # Set version of linuxptp to 3.1.1
-PREFERRED_VERSION_libvirt = "3.1.1"
+PREFERRED_VERSION_linuxptp = "3.1.1"
 


### PR DESCRIPTION
Previously, 'PREFERRED_VERSION' was used to specify the preferred version of a recipe in the 'distro' module. With this if the version is not found a warning will be raised and another version is used instead. To avoid this, 'REQUIRED_VERSION' is now used instead of 'PREFERRED_VERSION'. This generates an error if the required version is not found, instead of a warning. This change should help to prevent unexpected behavior and make the code more robust.
