### PR TITLE
migrate the override syntax to the new syntax

### DIFF
--- a/classes/overlay.inc
+++ b/classes/overlay.inc
@@ -3,7 +3,7 @@
 
 #
 
-VOLATILE_BINDS_pn-volatile-binds ?= "\
+VOLATILE_BINDS:pn-volatile-binds ?= "\
     /mnt/persistent/home /home\n\
     /var/volatile/usr/lib/python3.8/site-packages/__pycache__ /usr/lib/python3.8/site-packages/__pycache__\n\
     /mnt/persistent/var/lib /var/lib\n\

--- a/conf/distro/include/enable-uefi-secureboot.inc
+++ b/conf/distro/include/enable-uefi-secureboot.inc
@@ -5,7 +5,7 @@
 # to implement UEFI SecureBoot.
 
 # Set the UEFI SecureBoot feature
-DISTRO_FEATURES_append = " efi-secure-boot"
+DISTRO_FEATURES:append = " efi-secure-boot"
 
 # Controls whether the signing is using samples or real keys
 SIGNING_MODEL = "user"
@@ -38,5 +38,5 @@ EFI_BOOT_PATH = "/boot/EFI/BOOT"
 
 # Set correct ESP partition target path for SELoader and
 # OVMF DXE drivers
-EFI_TARGET_pn-seloader = "${EFI_BOOT_PATH}"
-EFI_TARGET_pn-ovmf = "${EFI_BOOT_PATH}"
+EFI_TARGET:pn-seloader = "${EFI_BOOT_PATH}"
+EFI_TARGET:pn-ovmf = "${EFI_BOOT_PATH}"

--- a/conf/distro/seapath-common.inc
+++ b/conf/distro/seapath-common.inc
@@ -8,7 +8,7 @@ require conf/distro/poky.conf
 MAINTAINER = "support@savoirfairelinux.com"
 
 # Use systemd as default
-DISTRO_FEATURES_append = " systemd"
+DISTRO_FEATURES:append = " systemd"
 VIRTUAL-RUNTIME_init_manager = "systemd"
 VIRTUAL-RUNTIME_initscripts = "systemd-compat-units"
 
@@ -16,11 +16,11 @@ VIRTUAL-RUNTIME_initscripts = "systemd-compat-units"
 DISTRO_FEATURES_BACKFILL_CONSIDERED += "sysvinit"
 
 # No need for x11 and wayland
-DISTRO_FEATURES_remove = " x11"
-DISTRO_FEATURES_remove = " wayland"
+DISTRO_FEATURES:remove = " x11"
+DISTRO_FEATURES:remove = " wayland"
 
 # Remove unneeded distribution features
-DISTRO_FEATURES_remove = " 3g alsa bluetooth nfc nfs opengl pcmcia vulkan wifi zeroconf"
+DISTRO_FEATURES:remove = " 3g alsa bluetooth nfc nfs opengl pcmcia vulkan wifi zeroconf"
 DISTRO_FEATURES_BACKFILL_CONSIDERED += "pulseaudio gobject-introspection-data"
 
 # Active buildhistory
@@ -28,12 +28,12 @@ INHERIT += "buildhistory"
 BUILDHISTORY_COMMIT = "1"
 
 # Use virtualization features
-DISTRO_FEATURES_append = " virtualization"
-DISTRO_FEATURES_append = " kvm"
+DISTRO_FEATURES:append = " virtualization"
+DISTRO_FEATURES:append = " kvm"
 
 # Enable dpdk for openvswitch
-PACKAGECONFIG_append_pn-openvswitch = " dpdk"
-COMPATIBLE_MACHINE_pn-dpdk = "(votp)"
+PACKAGECONFIG:append:pn-openvswitch = " dpdk"
+COMPATIBLE_MACHINE:pn-dpdk = "(votp)"
 REQUIRED_VERSION_openvswitch = "2.15%"
 REQUIRED_VERSION_dpdk = "20.11.%"
 
@@ -48,11 +48,11 @@ VIRTUAL-RUNTIME_login_manager = "shadow-base"
 PNBLACKLIST[busybox] = "Don't build this"
 
 # Disable and blacklist cups
-PACKAGECONFIG_remove_pn-samba = "cups"
+PACKAGECONFIG:remove:pn-samba = "cups"
 PNBLACKLIST[cups] = "Don't build this"
 
 # Disable snapper module to remove unneeded dependency on dbus
-SAMBA4_MODULES_append_pn-samba = ",!vfs-snapper"
+SAMBA4_MODULES:append:pn-samba = ",!vfs-snapper"
 
 # Blacklist dtc
 PNBLACKLIST[dtc] = "Don't build this"
@@ -60,28 +60,28 @@ PNBLACKLIST[dtc] = "Don't build this"
 # Configure QEMU to:
 #     * disable audio support
 #     * only support x86 targets
-QEMU_TARGETS_pn-qemu = "i386 x86_64"
-PACKAGECONFIG_remove_pn-qemu = "fdt"
-EXTRA_OECONF_append_pn-qemu = " --audio-drv-list=''"
+QEMU_TARGETS:pn-qemu = "i386 x86_64"
+PACKAGECONFIG:remove:pn-qemu = "fdt"
+EXTRA_OECONF:append:pn-qemu = " --audio-drv-list=''"
 
 # Enable ptest
-DISTRO_FEATURES_append = " ptest"
+DISTRO_FEATURES:append = " ptest"
 
 # Enable pam
-DISTRO_FEATURES_append = " pam"
+DISTRO_FEATURES:append = " pam"
 
 # Enable security hardening
-DISTRO_FEATURES_append = " seapath-security"
+DISTRO_FEATURES:append = " seapath-security"
 
 # Enable Ansible SSH key copy
-DISTRO_FEATURES_append = " ansible"
+DISTRO_FEATURES:append = " ansible"
 
 # Enable readonly
-DISTRO_FEATURES_append = " seapath-readonly"
-DISTRO_FEATURES_append = " seapath-overlay"
+DISTRO_FEATURES:append = " seapath-readonly"
+DISTRO_FEATURES:append = " seapath-overlay"
 
 # Enable clustering
-DISTRO_FEATURES_append = " seapath-clustering"
+DISTRO_FEATURES:append = " seapath-clustering"
 
 # Set version of Libvirt to 6.3.0 (solves GH issue #22)
 REQUIRED_VERSION_libvirt = "6.3.0"

--- a/conf/distro/seapath-flash.conf
+++ b/conf/distro/seapath-flash.conf
@@ -17,6 +17,6 @@ INHERIT += "buildhistory"
 BUILDHISTORY_COMMIT = "1"
 
 # Enable Ansible SSH key copy
-DISTRO_FEATURES_append = " ansible"
+DISTRO_FEATURES:append = " ansible"
 
-COMPATIBLE_MACHINE_pn-dpdk = "votp"
+COMPATIBLE_MACHINE:pn-dpdk = "votp"

--- a/conf/distro/seapath-guest.conf
+++ b/conf/distro/seapath-guest.conf
@@ -9,8 +9,8 @@ DISTRO_NAME = "Seapath guest Yocto distribution"
 DISTRO_VERSION = "1.0"
 
 #Remove uneeded features
-DISTRO_FEATURES_remove = "seapath-clustering"
-DISTRO_FEATURES_remove = "seapath-readonly"
-DISTRO_FEATURES_remove = "seapath-overlay"
-DISTRO_FEATURES_remove = "kvm"
-DISTRO_FEATURES_remove = "virtualization"
+DISTRO_FEATURES:remove = "seapath-clustering"
+DISTRO_FEATURES:remove = "seapath-readonly"
+DISTRO_FEATURES:remove = "seapath-overlay"
+DISTRO_FEATURES:remove = "kvm"
+DISTRO_FEATURES:remove = "virtualization"

--- a/conf/distro/seapath-host-cluster-minimal.conf
+++ b/conf/distro/seapath-host-cluster-minimal.conf
@@ -9,5 +9,5 @@ DISTRO_NAME = "Seapath Host Cluster Minimal Yocto distribution"
 DISTRO_VERSION = "1.0"
 
 #Remove uneeded features
-DISTRO_FEATURES_remove = "seapath-readonly"
-DISTRO_FEATURES_remove = "seapath-security"
+DISTRO_FEATURES:remove = "seapath-readonly"
+DISTRO_FEATURES:remove = "seapath-security"

--- a/conf/distro/seapath-host-minimal.conf
+++ b/conf/distro/seapath-host-minimal.conf
@@ -9,9 +9,9 @@ DISTRO_NAME = "Seapath Host Minimal Yocto distribution"
 DISTRO_VERSION = "1.0"
 
 #Remove uneeded features
-DISTRO_FEATURES_remove = "seapath-clustering"
-DISTRO_FEATURES_remove = "seapath-readonly"
-DISTRO_FEATURES_remove = "seapath-security"
+DISTRO_FEATURES:remove = "seapath-clustering"
+DISTRO_FEATURES:remove = "seapath-readonly"
+DISTRO_FEATURES:remove = "seapath-security"
 
 # Remove uneeded package configuration
-PACKAGECONFIG_remove_pn-net-snmp = "cluster"
+PACKAGECONFIG:remove:pn-net-snmp = "cluster"

--- a/conf/machine/votp-guest.conf
+++ b/conf/machine/votp-guest.conf
@@ -7,4 +7,4 @@
 #@DESCRIPTION: Machine configuration for virtual machines compatible with SEAPATH
 
 require conf/machine/votp-machine-common.inc
-MACHINE_FEATURES_append = "seapath-guest"
+MACHINE_FEATURES:append = "seapath-guest"

--- a/recipes-bsp/amd-ucode/amd-ucode_20220509.bb
+++ b/recipes-bsp/amd-ucode/amd-ucode_20220509.bb
@@ -40,5 +40,5 @@ do_install() {
 }
 
 
-FILES_${PN} = "${nonarch_base_libdir}/firmware/*"
+FILES:${PN} = "${nonarch_base_libdir}/firmware/*"
 

--- a/recipes-bsp/grub/grub-efi_%.bbappend
+++ b/recipes-bsp/grub/grub-efi_%.bbappend
@@ -1,17 +1,17 @@
 # Copyright (C) 2021, RTE (http://www.rte-france.com)
 # SPDX-License-Identifier: Apache-2.0
 
-FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 SRC_URI += " \
     file://0001-probe-Support-probing-for-partition-UUID-with-part-u.patch \
 "
 
-SRC_URI_append_class-target = " \
+SRC_URI:append:class-target = " \
     file://grub-efi.cfg.in   \
 "
 
-do_compile_append_class-target() {
+do_compile:append:class-target() {
     grub_timeout=0
     grub_password='grub.pbkdf2.sha512.65536.93A962261977428CADFAF1C7EAD6339B40F422991C7F86FECC8E44411686C9E36FE7B5E7352DE3F2E29042CD7A95FDFFF9998C6A6EF80F98F05C763D754AFF2F6B9A321C8FB452F93DE72457B8E89C0DD46ACDE0C7598DD67E9D730931624CD29F972EE568248DC4734A42E127316CAB87C2EC05C538BFC65B7BF6A3581582BEFD596551B383567BE95DF1B498F93867FF074E4FBF09C5BCA266E484EC22A0BD6AD2EA9E1D8DAF67FDCCEEFA4614A65BC8EB857903A012DA4FFBC0161E8F775FF173031913437567AC42E7C015A851DABD0BAF2ECBF01F3A4C38F024A74ABC3E07ABD697E5AB63EFCC0C7A91725FBB86D71A1CBE84893A876B8BD225F928581F.4E8A15EEAFD2AEFC1338A1F31B26D1B7C2ABA9C5FCE0858A05C8456D24EF994974883825900241959B8B35B73AC913437FC24AF80B6DBFF1FBD32770CF118DDD'
     if [ -n "${SEAPATH_GRUB_TIMEOUT}" ] ; then
@@ -41,7 +41,7 @@ do_compile_append_class-target() {
     cat "${WORKDIR}/grub-efi.cfg.in" >> "${B}/grub-efi.cfg"
 }
 
-do_install_prepend_class-target_votp-host() {
+do_install:prepend:class-target_votp-host() {
     extra_append=""
     if [ -n "${SEAPATH_RT_CORES}" ] ; then
         extra_append="isolcpus=${SEAPATH_RT_CORES} nohz_full=${SEAPATH_RT_CORES} rcu_nocbs=${SEAPATH_RT_CORES}"
@@ -51,7 +51,7 @@ do_install_prepend_class-target_votp-host() {
 
 }
 
-do_install_append_class-target() {
+do_install:append:class-target() {
     if [ "${UEFI_SB}" != "1" ]; then
         install -D -m 0600 "${B}/grub-efi.cfg" "${D}${EFI_FILES_PATH}/grub.cfg"
     fi
@@ -63,15 +63,15 @@ do_install_append_class-target() {
 # also enabled.
 # "grub-efi" actually depends on MOK2Verify protocol being installed by
 # SELoader before its execution.
-RDEPENDS_${PN}_class-target_append = "${@' seloader' if (d.getVar('UEFI_SELOADER') == '1' and d.getVar('UEFI_SB') == '1') else ''}"
+RDEPENDS:${PN}:class-target:append = "${@' seloader' if (d.getVar('UEFI_SELOADER') == '1' and d.getVar('UEFI_SB') == '1') else ''}"
 
 # Remove dependency to grub-bootconf as the configuration is installed
 # in grub-efi
-RDEPENDS_${PN}_class-target_remove = "virtual/grub-bootconf"
+RDEPENDS:${PN}:class-target:remove = "virtual/grub-bootconf"
 
-FILES_${PN}_remove = "${libdir}/grub"
+FILES:${PN}:remove = "${libdir}/grub"
 
-FILES_${PN}_append = " ${EFI_FILES_PATH}"
+FILES:${PN}:append = " ${EFI_FILES_PATH}"
 
 GRUB_BUILDIN += " password_pbkdf2 probe regexp chain"
 

--- a/recipes-bsp/keymaps/keymaps_%.bbappend
+++ b/recipes-bsp/keymaps/keymaps_%.bbappend
@@ -1,7 +1,7 @@
 # Copyright (C) 2021, RTE (http://www.rte-france.com)
 # SPDX-License-Identifier: Apache-2.0
 
-do_configure_prepend () {
+do_configure:prepend () {
     if [ -z "${SEAPATH_KEYMAP}" ] ; then
          SEAPATH_KEYMAP=us
     fi

--- a/recipes-cgl/cluster-glue/cluster-glue_%.bbappend
+++ b/recipes-cgl/cluster-glue/cluster-glue_%.bbappend
@@ -2,11 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 #to add hacluster to the msmtp group, so that it can write to msmtp log file
-RDEPENDS_${PN} += "msmtp"
+RDEPENDS:${PN} += "msmtp"
 DEPENDS += "msmtp"
-USERADD_PARAM_${PN}:prepend = " -G msmtp "
+USERADD_PARAM:${PN}:prepend = " -G msmtp "
 
-do_install_append() {
+do_install:append() {
     for file in $(find ${D}${libdir}/stonith/plugins/external -type f); do
         sed -i "s%${HOSTTOOLS_DIR}/%%g" "${file}"
     done

--- a/recipes-cgl/cluster-resource-agents/resource-agents_4.5.0.bbappend
+++ b/recipes-cgl/cluster-resource-agents/resource-agents_4.5.0.bbappend
@@ -1,15 +1,15 @@
 # Copyright (C) 2021, RTE (http://www.rte-france.com)
 # SPDX-License-Identifier: Apache-2.0
 
-FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 SRC_URI += "file://VirtualDomain"
-SRC_URI_remove = "git://github.com/ClusterLabs/resource-agents"
+SRC_URI:remove = "git://github.com/ClusterLabs/resource-agents"
 SRC_URI += "git://github.com/ClusterLabs/resource-agents;nobranch=1"
 
 REQUIRED_HEARTBEAT_SCRIPTS = "VirtualDomain"
 
-do_install_append() {
+do_install:append() {
     # Remove tools and libraries used for NFS filesystem manipulations
     #
     # Note: resource-agents detects if "svclib_nfslock" is installed
@@ -59,5 +59,5 @@ do_install_append() {
     sed -i "s%${HOSTTOOLS_DIR}/rm%/bin/rm%g" ${D}${base_libdir}/systemd/system/ldirectord.service
 }
 
-FILES_${PN} += "${libdir}/ocf/resource.d/seapath/VirtualDomain"
-RDEPENDS_${PN}_remove = "lvm2 nfs-utils"
+FILES:${PN} += "${libdir}/ocf/resource.d/seapath/VirtualDomain"
+RDEPENDS:${PN}:remove = "lvm2 nfs-utils"

--- a/recipes-cgl/crmsh/crmsh_4.20.bbappend
+++ b/recipes-cgl/crmsh/crmsh_4.20.bbappend
@@ -1,7 +1,7 @@
 # Copyright (C) 2020, RTE (http://www.rte-france.com)
 # SPDX-License-Identifier: Apache-2.0
 
-DEPENDS_remove = "python-setuptools-native"
-DEPENDS_append = " python3-setuptools-native"
+DEPENDS:remove = "python-setuptools-native"
+DEPENDS:append = " python3-setuptools-native"
 
-RDEPENDS_${PN}_append = " python3-pyyaml"
+RDEPENDS:${PN}:append = " python3-pyyaml"

--- a/recipes-cgl/pacemaker/pacemaker_%.bbappend
+++ b/recipes-cgl/pacemaker/pacemaker_%.bbappend
@@ -7,9 +7,9 @@ SERVICE_DIRS_LIST = "pacemaker"
 SERVICE_DIRS_PREFIX = "{log,lib}"
 SERVICE_DIRS_OWNER = "hacluster:haclient"
 
-FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
-SRC_URI_remove = "git://github.com/ClusterLabs/${BPN}.git"
+SRC_URI:remove = "git://github.com/ClusterLabs/${BPN}.git"
 
 SRC_URI += " \
     git://github.com/ClusterLabs/${BPN}.git;nobranch=1 \
@@ -19,7 +19,7 @@ SRC_URI += " \
     file://alert_snmp.sh \
 "
 
-do_install_append() {
+do_install:append() {
     install -d ${D}/${systemd_unitdir}/system/
     install -m 644 ${WORKDIR}/create-var-run-resource-agents.service \
         ${D}/${systemd_unitdir}/system/create-var-run-resource-agents.service
@@ -31,7 +31,7 @@ do_install_append() {
     install --mode=0755 ${WORKDIR}/alert_snmp.sh ${D}${localstatedir}/lib/pacemaker/alert_snmp.sh
 }
 
-FILES_${PN} += " \
+FILES:${PN} += " \
     ${systemd_unitdir}/system/create-var-run-resource-agents.service \
     ${systemd_unitdir}/system/pacemaker.service \
 "

--- a/recipes-connectivity/openssh/openssh_%.bbappend
+++ b/recipes-connectivity/openssh/openssh_%.bbappend
@@ -1,14 +1,14 @@
 # Copyright (C) 2021, RTE (http://www.rte-france.com)
 # SPDX-License-Identifier: Apache-2.0
 
-FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 SRC_URI += " \
     file://sshd_config_seapath \
     file://sshd_config_seapath_flash \
 "
 
-do_install_append() {
+do_install:append() {
     # Use permanent SSH keys
     if ${@bb.utils.contains('DISTRO_FEATURES','seapath-readonly','true','false',d)}; then
         install -d ${D}${sysconfdir}/ssh
@@ -23,7 +23,7 @@ do_install_append() {
     fi
 }
 
-do_install_append_seapath-flash() {
+do_install:append_seapath-flash() {
     install -d ${D}${sysconfdir}/ssh
     install -m 0644 ${WORKDIR}/sshd_config_seapath_flash \
         ${D}${sysconfdir}/ssh/sshd_config

--- a/recipes-core/base-files/base-files_%.bbappend
+++ b/recipes-core/base-files/base-files_%.bbappend
@@ -1,11 +1,11 @@
 # Copyright (C) 2020, RTE (http://www.rte-france.com)
 # SPDX-License-Identifier: Apache-2.0
 
-FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 SRC_URI += "file://nsswitch.conf"
 
-do_install_append() {
+do_install:append() {
     if ${@bb.utils.contains('DISTRO_FEATURES','seapath-security','true','false',d)}; then
         install -m 755 -d ${D}/etc/
         install -m 644 ${WORKDIR}/nsswitch.conf ${D}/etc/

--- a/recipes-core/base-passwd/base-passwd_%.bbappend
+++ b/recipes-core/base-passwd/base-passwd_%.bbappend
@@ -1,10 +1,10 @@
-FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
-SRC_URI_prepend = " \
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+SRC_URI:prepend = " \
     file://passwd.master \
     file://group.master \
 "
 
-do_configure_prepend () {
+do_configure:prepend () {
     if ${@bb.utils.contains('DISTRO_FEATURES','seapath-security','true','false',d)}; then
         cp -v ${WORKDIR}/passwd.master ${S}/
         cp -v ${WORKDIR}/group.master ${S}/

--- a/recipes-core/images/seapath-common.inc
+++ b/recipes-core/images/seapath-common.inc
@@ -4,7 +4,7 @@
 DESCRIPTION = "A common base for Seapath images"
 LICENSE = "Apache-2.0"
 require recipes-core/images/core-image-minimal.bb
-IMAGE_INSTALL_append = " \
+IMAGE_INSTALL:append = " \
     cukinia-tests \
     cukinia-tests-common \
     ${@bb.utils.contains('DISTRO_FEATURES','seapath-security','cukinia-tests-common-security','',d)} \
@@ -12,25 +12,25 @@ IMAGE_INSTALL_append = " \
     system-config-common \
 "
 # Add kernel-modules
-IMAGE_INSTALL_append = " \
+IMAGE_INSTALL:append = " \
     kernel-modules \
 "
 
 # Ansible required modules
-IMAGE_INSTALL_append = " \
+IMAGE_INSTALL:append = " \
     python3-json \
     python3-modules \
 "
 
-IMAGE_INSTALL_append = " less"
+IMAGE_INSTALL:append = " less"
 
 IMAGE_FEATURES += "ssh-server-openssh"
-IMAGE_INSTALL_append = " openssh-sftp-server"
+IMAGE_INSTALL:append = " openssh-sftp-server"
 
-IMAGE_INSTALL_append = " syslog-ng"
+IMAGE_INSTALL:append = " syslog-ng"
 
 # AMD micro-codes
-IMAGE_INSTALL_append = " amd-ucode"
+IMAGE_INSTALL:append = " amd-ucode"
 
 GLIBC_GENERATE_LOCALES = "en_US.UTF-8"
 IMAGE_LINGUAS = "en-us"

--- a/recipes-core/images/seapath-efi-common.inc
+++ b/recipes-core/images/seapath-efi-common.inc
@@ -4,8 +4,8 @@
 inherit deploy
 inherit boot-partition
 
-IMAGE_INSTALL_remove = "grub"
-IMAGE_INSTALL_append = " \
+IMAGE_INSTALL:remove = "grub"
+IMAGE_INSTALL:append = " \
     grub-efi             \
     efitools             \
     efibootmgr           \

--- a/recipes-core/images/seapath-flash-common.inc
+++ b/recipes-core/images/seapath-flash-common.inc
@@ -3,7 +3,7 @@
 DESCRIPTION = "A common base for image used to flash Seapath images"
 LICENSE = "Apache-2.0"
 require recipes-core/images/core-image-minimal.bb
-IMAGE_INSTALL_append = " \
+IMAGE_INSTALL:append = " \
     bmap-tools \
     e2fsprogs-mke2fs \
     flash-script \
@@ -13,13 +13,13 @@ IMAGE_INSTALL_append = " \
     kbd-keymaps \
 "
 # Add kernel-modules
-IMAGE_INSTALL_append = " \
+IMAGE_INSTALL:append = " \
     kernel-modules \
 "
 
-IMAGE_INSTALL_append = " openssh-sshd openssh-sftp-server"
+IMAGE_INSTALL:append = " openssh-sshd openssh-sftp-server"
 
-IMAGE_INSTALL_append = " less"
+IMAGE_INSTALL:append = " less"
 
 GLIBC_GENERATE_LOCALES = "en_US.UTF-8 fr_FR.UTF-8"
 IMAGE_LINGUAS ?= "en_US fr_FR"

--- a/recipes-core/images/seapath-flash-pxe.bb
+++ b/recipes-core/images/seapath-flash-pxe.bb
@@ -13,7 +13,7 @@ INITRAMFS_MAXSIZE = "262144"
 
 
 # Install EFI tools
-IMAGE_INSTALL_append = " \
+IMAGE_INSTALL:append = " \
     efitools             \
     efibootmgr           \
 "

--- a/recipes-core/images/seapath-guest-common.inc
+++ b/recipes-core/images/seapath-guest-common.inc
@@ -7,7 +7,7 @@ require seapath-common.inc
 
 inherit ${@bb.utils.contains('DISTRO_FEATURES', 'seapath-security', 'security/qa-guest-images', '', d)}
 
-IMAGE_INSTALL_append = " \
+IMAGE_INSTALL:append = " \
     cukinia-tests-vm \
     syslog-ng-client \
     system-config-security \
@@ -29,7 +29,7 @@ COMPATIBLE_MACHINE = "votp-guest"
 
 # Remove users that do not exist in
 # guest images
-USERS_LIST_LOCKED_remove = "qemu ceph"
+USERS_LIST_LOCKED:remove = "qemu ceph"
 
 def get_seapath_kernel_parameters(d):
     disable_ipv6 = d.getVar("SEAPATH_GUEST_DISABLE_IPV6", "")

--- a/recipes-core/images/seapath-guest-host-common.inc
+++ b/recipes-core/images/seapath-guest-host-common.inc
@@ -5,7 +5,7 @@ DESCRIPTION = "A common base for host and guest image"
 
 require seapath-host-common.inc
 
-IMAGE_INSTALL_append = " \
+IMAGE_INSTALL:append = " \
    pacemaker-remote \
 "
 IMAGE_FSTYPES = "wic.qcow2 wic.vmdk"

--- a/recipes-core/images/seapath-host-common-ha.inc
+++ b/recipes-core/images/seapath-host-common-ha.inc
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # HA
-IMAGE_INSTALL_append = " \
+IMAGE_INSTALL:append = " \
     cluster-glue \
     cluster-glue-plugin-stonith2 \
     cluster-glue-plugin-stonith2-ribcl \

--- a/recipes-core/images/seapath-host-common-virtu.inc
+++ b/recipes-core/images/seapath-host-common-virtu.inc
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Virtualization
-IMAGE_INSTALL_append = " \
+IMAGE_INSTALL:append = " \
     dpdk-tools \
     libvirt \
     libvirt-libvirtd \

--- a/recipes-core/images/seapath-host-common.inc
+++ b/recipes-core/images/seapath-host-common.inc
@@ -9,7 +9,7 @@ require seapath-host-common-virtu.inc
 inherit ${@bb.utils.contains('DISTRO_FEATURES', 'seapath-security', 'security/qa-host-images', '', d)}
 
 # Hypervisor and cluster tests
-IMAGE_INSTALL_append = " \
+IMAGE_INSTALL:append = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'seapath-clustering', 'cukinia-tests-cluster', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'seapath-clustering', \
             bb.utils.contains('DISTRO_FEATURES', 'seapath-security', \
@@ -29,8 +29,8 @@ IMAGE_INSTALL_append = " \
     irqbalance \
 "
 
-IMAGE_INSTALL_append = " cukinia-tests-hypervisor-iommu"
-IMAGE_INSTALL_remove_votp-no-iommu = "cukinia-tests-hypervisor-iommu"
+IMAGE_INSTALL:append = " cukinia-tests-hypervisor-iommu"
+IMAGE_INSTALL:remove_votp-no-iommu = "cukinia-tests-hypervisor-iommu"
 
 # Host images are compatible with votp-host only
 # GRUB static configuration for host machines

--- a/recipes-core/images/seapath-host-efi-dbg-swu-image.bb
+++ b/recipes-core/images/seapath-host-efi-dbg-swu-image.bb
@@ -3,7 +3,7 @@
 
 DESCRIPTION = "SWUpdate upgrade image for SEAPATH"
 LICENSE = "Apache-2.0"
-FILESEXTRAPATHS_prepend := "${THISDIR}/files/hosts:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/files/hosts:"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
 
 inherit swupdate

--- a/recipes-core/images/seapath-host-efi-swu-image.bb
+++ b/recipes-core/images/seapath-host-efi-swu-image.bb
@@ -3,7 +3,7 @@
 
 DESCRIPTION = "SWUpdate upgrade image for SEAPATH"
 LICENSE = "Apache-2.0"
-FILESEXTRAPATHS_prepend := "${THISDIR}/files/hosts:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/files/hosts:"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
 
 inherit swupdate

--- a/recipes-core/images/seapath-monitor-bios-image.bb
+++ b/recipes-core/images/seapath-monitor-bios-image.bb
@@ -8,4 +8,4 @@ require seapath-monitor-common.inc
 
 WKS_FILE = "mkbiosdisk.wks.in"
 
-IMAGE_INSTALL_append = " syslog-ng-server"
+IMAGE_INSTALL:append = " syslog-ng-server"

--- a/recipes-core/images/seapath-monitor-common.inc
+++ b/recipes-core/images/seapath-monitor-common.inc
@@ -1,9 +1,9 @@
 # Copyright (C) 2022, RTE (http://www.rte-france.com)
 # SPDX-License-Identifier: Apache-2.0
 
-USERS_LIST_LOCKED_remove = "qemu"
+USERS_LIST_LOCKED:remove = "qemu"
 
-IMAGE_INSTALL_append = " \
+IMAGE_INSTALL:append = " \
     cukinia-tests-monitor \
     system-upgrade \
 "

--- a/recipes-core/images/seapath-monitor-efi-image.bb
+++ b/recipes-core/images/seapath-monitor-efi-image.bb
@@ -8,4 +8,4 @@ require seapath-host-common-ha.inc
 require seapath-monitor-common.inc
 require seapath-swupdate-common.inc
 
-IMAGE_INSTALL_append = " syslog-ng-server"
+IMAGE_INSTALL:append = " syslog-ng-server"

--- a/recipes-core/images/seapath-monitor-efi-swu-image.bb
+++ b/recipes-core/images/seapath-monitor-efi-swu-image.bb
@@ -3,7 +3,7 @@
 
 DESCRIPTION = "SWUpdate upgrade monitor image for SEAPATH"
 LICENSE = "Apache-2.0"
-FILESEXTRAPATHS_prepend := "${THISDIR}/files/monitor:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/files/monitor:"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
 
 inherit swupdate

--- a/recipes-core/images/seapath-swupdate-common.inc
+++ b/recipes-core/images/seapath-swupdate-common.inc
@@ -4,7 +4,7 @@
 inherit deploy
 inherit boot-partition
 
-IMAGE_INSTALL_append = " \
+IMAGE_INSTALL:append = " \
     swupdate             \
     dosfstools           \
     localedef            \

--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -1,16 +1,16 @@
 # Copyright (C) 2021, RTE (http://www.rte-france.com)
 # SPDX-License-Identifier: Apache-2.0
 
-FILESEXTRAPATHS_prepend :="${THISDIR}/files:"
-SRC_URI_append = " \
+FILESEXTRAPATHS:prepend :="${THISDIR}/files:"
+SRC_URI:append = " \
     file://0001-networkd-wait-online-add-any-option.patch \
     file://basic.conf \
     file://boot-complete.target \
     file://journald.conf \
     file://resolved.conf \
 "
-PACKAGECONFIG_append = " seccomp"
-do_install_append () {
+PACKAGECONFIG:append = " seccomp"
+do_install:append () {
     install -m 0644 ${WORKDIR}/basic.conf ${D}/usr/lib/sysusers.d/
     # Remove audio group references
     sed '/- audio -/d' -i ${D}/usr/lib/tmpfiles.d/static-nodes-permissions.conf

--- a/recipes-cukinia-tests/cukinia-tests/cukinia-tests.bb
+++ b/recipes-cukinia-tests/cukinia-tests/cukinia-tests.bb
@@ -76,8 +76,8 @@ SRC_URI = "\
     file://hypervisor_iommu_tests.d/kernel.conf \
 "
 
-RDEPENDS_${PN} += "cukinia"
-RDEPENDS_${PN} += "bash coreutils pciutils"
+RDEPENDS:${PN} += "cukinia"
+RDEPENDS:${PN} += "bash coreutils pciutils"
 
 do_install () {
     install -m 0755 -d ${D}${sysconfdir}/cukinia/
@@ -253,74 +253,74 @@ PACKAGES =+ " \
     ${PN}-efi \
 "
 
-RDEPENDS_${PN}-realtime += "rt-tests"
-RDEPENDS_${PN}-vm += "${PN}-common"
+RDEPENDS:${PN}-realtime += "rt-tests"
+RDEPENDS:${PN}-vm += "${PN}-common"
 
-FILES_${PN} = " \
+FILES:${PN} = " \
     ${sysconfdir}/cukinia/cukinia.conf \
     ${datadir}/cukinia/includes \
 "
 
-FILES_${PN}-cluster = " \
+FILES:${PN}-cluster = " \
     ${sysconfdir}/cukinia/cukinia-cluster.conf \
     ${sysconfdir}/cukinia/configurations/cukinia-cluster-common.conf \
     ${sysconfdir}/cukinia/cluster_tests.d/* \
 "
 
-FILES_${PN}-cluster-security = " \
+FILES:${PN}-cluster-security = " \
     ${sysconfdir}/cukinia/configurations/cukinia-cluster-security.conf \
     ${sysconfdir}/cukinia/cluster_security_tests.d/* \
 "
 
-FILES_${PN}-common = " \
+FILES:${PN}-common = " \
     ${sysconfdir}/cukinia/cukinia-common.conf \
     ${sysconfdir}/cukinia/configurations/cukinia-common.conf \
     ${sysconfdir}/cukinia/common_tests.d/* \
 "
 
-FILES_${PN}-common-security = " \
+FILES:${PN}-common-security = " \
     ${sysconfdir}/cukinia/cukinia-sec.conf \
     ${sysconfdir}/cukinia/configurations/cukinia-common-security.conf \
     ${sysconfdir}/cukinia/common_security_tests.d/* \
 "
 
-FILES_${PN}-hypervisor = " \
+FILES:${PN}-hypervisor = " \
     ${sysconfdir}/cukinia/cukinia-hypervisor.conf \
     ${sysconfdir}/cukinia/configurations/cukinia-hypervisor-common.conf \
     ${sysconfdir}/cukinia/hypervisor_tests.d/* \
 "
 
-FILES_${PN}-hypervisor-readonly = " \
+FILES:${PN}-hypervisor-readonly = " \
     ${sysconfdir}/cukinia/configurations/cukinia-hypervisor-readonly.conf \
     ${sysconfdir}/cukinia/hypervisor_readonly_tests.d/* \
 "
 
-FILES_${PN}-hypervisor-security = " \
+FILES:${PN}-hypervisor-security = " \
     ${sysconfdir}/cukinia/configurations/cukinia-hypervisor-security.conf \
     ${sysconfdir}/cukinia/hypervisor_security_tests.d/* \
 "
 
-FILES_${PN}-hypervisor-iommu = " \
+FILES:${PN}-hypervisor-iommu = " \
     ${sysconfdir}/cukinia/configurations/cukinia-hypervisor-iommu.conf \
     ${sysconfdir}/cukinia/hypervisor_iommu_tests.d/* \
 "
 
-FILES_${PN}-monitor = " \
+FILES:${PN}-monitor = " \
     ${sysconfdir}/cukinia/cukinia-monitor.conf \
     ${sysconfdir}/cukinia/monitor_tests.d/* \
 "
 
-FILES_${PN}-realtime = " \
+FILES:${PN}-realtime = " \
     ${sysconfdir}/cukinia/cukinia-realtime.conf \
     ${sysconfdir}/cukinia/realtime_tests.d/* \
 "
 
-FILES_${PN}-vm = " \
+FILES:${PN}-vm = " \
     ${sysconfdir}/cukinia/cukinia-vm.conf \
     ${sysconfdir}/cukinia/vm_tests.d/* \
 "
 
-FILES_${PN}-efi = " \
+FILES:${PN}-efi = " \
     ${sysconfdir}/cukinia/cukinia-efi.conf \
     ${sysconfdir}/cukinia/efi_tests.d/* \
 "

--- a/recipes-devtools/qemu/qemu_%.bbappend
+++ b/recipes-devtools/qemu/qemu_%.bbappend
@@ -1,5 +1,5 @@
 # Copyright (C) 2020, RTE (http://www.rte-france.com)
 # SPDX-License-Identifier: Apache-2.0
 
-EXTRA_OECONF_append_class-target = "${@bb.utils.contains('DISTRO_FEATURES','seapath-clustering', " --enable-rbd", "",d)}"
-DEPENDS_append_class-target = "${@bb.utils.contains('DISTRO_FEATURES','seapath-clustering'," ceph", "",d)}"
+EXTRA_OECONF:append:class-target = "${@bb.utils.contains('DISTRO_FEATURES','seapath-clustering', " --enable-rbd", "",d)}"
+DEPENDS:append:class-target = "${@bb.utils.contains('DISTRO_FEATURES','seapath-clustering'," ceph", "",d)}"

--- a/recipes-extended/ceph/ceph_%.bbappend
+++ b/recipes-extended/ceph/ceph_%.bbappend
@@ -1,7 +1,7 @@
 inherit useradd
 
 USERADD_PACKAGES= "${PN}"
-USERADD_PARAM_${PN} = "--system --no-create-home --home-dir /var/lib/ceph \
+USERADD_PARAM:${PN} = "--system --no-create-home --home-dir /var/lib/ceph \
     --shell /bin/nologin --user-group -c 'Ceph daemons' ceph"
 
 EXTRA_OECMAKE = "-DWITH_MANPAGE=OFF \
@@ -28,7 +28,7 @@ def limit_parallel(d):
 
 PARALLEL_MAKE = "${@limit_parallel(d)}"
 
-do_install_append () {
+do_install:append () {
 	for directory in / mon osd mds tmp radosgw bootstrap-rgw bootstrap-mgr \
 		bootstrap-mds bootstrap-osd bootstrap-rbd bootstrap-rbd-mirror
 	do
@@ -43,7 +43,7 @@ do_install_append () {
         done
 }
 
-do_install_append_class-target () {
+do_install:append:class-target () {
         if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then
                 install -d ${D}${sysconfdir}/tmpfiles.d
                 echo "d /var/lib/ceph/crash/ 0750 ceph ceph - -" > ${D}${sysconfdir}/tmpfiles.d/ceph-placeholder.conf
@@ -59,7 +59,7 @@ do_install_append_class-target () {
         fi
 }
 
-RDEPENDS_${PN} += "\
+RDEPENDS:${PN} += "\
 		python3-dateutil \
 		python3-requests \
 		lvm2 \

--- a/recipes-extended/corosync/corosync_%.bbappend
+++ b/recipes-extended/corosync/corosync_%.bbappend
@@ -6,14 +6,14 @@ inherit create-dirs
 SERVICE_DIRS_LIST = "corosync"
 SERVICE_DIRS_PREFIX = "{lib,log}"
 
-FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 SRC_URI += " \
     file://corosync.service \
     file://create-corosync-pid.service \
 "
 
-do_install_append() {
+do_install:append() {
     install -d ${D}/${systemd_unitdir}/system/
     install -m 644 ${WORKDIR}/corosync.service \
         ${D}/${systemd_unitdir}/system/corosync.service
@@ -21,11 +21,11 @@ do_install_append() {
         ${D}/${systemd_unitdir}/system/create-corosync-pid.service
 }
 
-SYSTEMD_SERVICE_${PN} += " \
+SYSTEMD_SERVICE:${PN} += " \
     create-corosync-pid.service \
 "
 
-FILES_${PN} += " \
+FILES:${PN} += " \
     ${systemd_unitdir}/system/corosync.service \
     ${systemd_unitdir}/system/create-corosync-pid.service \
 "

--- a/recipes-extended/dpdk/dpdk_20.%.bbappend
+++ b/recipes-extended/dpdk/dpdk_20.%.bbappend
@@ -1,10 +1,10 @@
 # Copyright (C) 2022, RTE (http://www.rte-france.com)
 # SPDX-License-Identifier: Apache-2.0
 
-do_install_append() {
+do_install:append() {
     install -m 0755 -d ${D}/${sbindir}
     ln -s ${bindir}/dpdk-devbind.py ${D}/${sbindir}/dpdk-devbind
 
 }
 
-FILES_${PN}-tools += "${sbindir}/dpdk-devbind"
+FILES:${PN}-tools += "${sbindir}/dpdk-devbind"

--- a/recipes-extended/irqbalance/irqbalance_1.9.2.bb
+++ b/recipes-extended/irqbalance/irqbalance_1.9.2.bb
@@ -23,9 +23,9 @@ DEPENDS = "glib-2.0"
 inherit autotools pkgconfig systemd
 
 SYSTEMD_PACKAGES = "irqbalance"
-SYSTEMD_SERVICE_irqbalance = "irqbalance.service"
+SYSTEMD_SERVICE:irqbalance = "irqbalance.service"
 
-do_install_append () {
+do_install:append () {
     install -d ${D}${systemd_unitdir}/system
     install -m 0644 ${WORKDIR}/irqbalance.service \
         ${D}${systemd_unitdir}/system/irqbalance.service

--- a/recipes-extended/kronosnet/kronosnet_%.bbappend
+++ b/recipes-extended/kronosnet/kronosnet_%.bbappend
@@ -1,4 +1,4 @@
 # Copyright (C) 2019-2023 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-EXTRA_OECONF_append = " --disable-man"
+EXTRA_OECONF:append = " --disable-man"

--- a/recipes-extended/libvirt/libvirt_%.bbappend
+++ b/recipes-extended/libvirt/libvirt_%.bbappend
@@ -7,7 +7,7 @@ SERVICE_DIRS_LIST = "libvirt"
 SERVICE_DIRS_PREFIX = "{cache,lib,log,run}"
 SERVICE_DIRS_OWNER = "root:root"
 
-FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 SRC_URI += " \
     file://libvirtd \
@@ -17,7 +17,7 @@ SRC_URI += " \
     file://qemu.conf \
 "
 
-do_install_append() {
+do_install:append() {
     install -d ${D}/${sysconfdir}/sysconfig/
     install -m 0644 ${WORKDIR}/libvirtd \
         ${D}${sysconfdir}/sysconfig/libvirtd
@@ -40,7 +40,7 @@ do_install_append() {
     rm -f ${D}${sysconfdir}/libvirt/qemu/networks/default.xml
 }
 
-FILES_${PN} += " \
+FILES:${PN} += " \
     ${sysconfdir}/sysconfig/libvirtd \
     ${sysconfdir}/libvirt/libvirtd.conf \
     ${sysconfdir}/libvirt/qemu.conf \

--- a/recipes-extended/libvirt_6.3/libvirt-python.inc
+++ b/recipes-extended/libvirt_6.3/libvirt-python.inc
@@ -5,15 +5,15 @@ export STAGING_LIBDIR
 export BUILD_SYS 
 export HOST_SYS
 
-RDEPENDS_${PN}-python += "python3"
+RDEPENDS:${PN}-python += "python3"
 PACKAGECONFIG_${PN}-python[xen] = ",,,xen-python"
 
 PACKAGES += "${PN}-python-staticdev ${PN}-python-dev ${PN}-python-dbg ${PN}-python"
 
-FILES_${PN}-python-staticdev += "${PYTHON_SITEPACKAGES_DIR}/*.a"
-FILES_${PN}-python-dev += "${PYTHON_SITEPACKAGES_DIR}/*.la"
-FILES_${PN}-python-dbg += "${PYTHON_SITEPACKAGES_DIR}/.debug/"
-FILES_${PN}-python = "${bindir}/* ${libdir}/* ${libdir}/${PYTHON_DIR}/*"
+FILES:${PN}-python-staticdev += "${PYTHON_SITEPACKAGES_DIR}/*.a"
+FILES:${PN}-python-dev += "${PYTHON_SITEPACKAGES_DIR}/*.la"
+FILES:${PN}-python-dbg += "${PYTHON_SITEPACKAGES_DIR}/.debug/"
+FILES:${PN}-python = "${bindir}/* ${libdir}/* ${libdir}/${PYTHON_DIR}/*"
 
 SRC_URI += "http://libvirt.org/sources/python/libvirt-python-${PV}.tar.gz;name=libvirt_python"
 
@@ -38,7 +38,7 @@ python __anonymous () {
         d.setVar('LIBVIRT_PYTHON_ENABLE', '0')
 }
 
-do_compile_append() {
+do_compile:append() {
 	if [ "${LIBVIRT_PYTHON_ENABLE}" = "1" ]; then
 		# we need the python bindings to look into our source dir, not
 		# the syroot staged pkgconfig entries. So we clear the sysroot
@@ -49,7 +49,7 @@ do_compile_append() {
 	fi
 }
 
-do_install_append() {
+do_install:append() {
 	if [ "${LIBVIRT_PYTHON_ENABLE}" = "1" ]; then
 		# we need the python bindings to look into our source dir, not
 		# the syroot staged pkgconfig entries. So we clear the sysroot

--- a/recipes-extended/libvirt_6.3/libvirt_6.3.0.bb
+++ b/recipes-extended/libvirt_6.3/libvirt_6.3.0.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "A toolkit to interact with the virtualization capabilities of recent versions of Linux." 
 HOMEPAGE = "http://libvirt.org"
 LICENSE = "LGPLv2.1+ & GPLv2+"
-LICENSE_${PN}-ptest = "GPLv2+ & LGPLv2.1+"
+LICENSE:${PN}-ptest = "GPLv2+ & LGPLv2.1+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
                     file://COPYING.LESSER;md5=4b54a1fd55a448865a0b32d41598759d"
 SECTION = "console/tools"
@@ -14,16 +14,16 @@ DEPENDS = "bridge-utils gnutls libxml2 lvm2 avahi parted curl libpcap util-linux
 
 # libvirt-guests.sh needs gettext.sh
 #
-RDEPENDS_${PN} = "gettext-runtime"
+RDEPENDS:${PN} = "gettext-runtime"
 
-RDEPENDS_${PN}-ptest += "make gawk perl bash"
+RDEPENDS:${PN}-ptest += "make gawk perl bash"
 
-RDEPENDS_libvirt-libvirtd += "bridge-utils iptables pm-utils dnsmasq netcat-openbsd"
-RDEPENDS_libvirt-libvirtd_append_x86-64 = " dmidecode"
-RDEPENDS_libvirt-libvirtd_append_x86 = " dmidecode"
+RDEPENDS:libvirt-libvirtd += "bridge-utils iptables pm-utils dnsmasq netcat-openbsd"
+RDEPENDS:libvirt-libvirtd:append:x86-64 = " dmidecode"
+RDEPENDS:libvirt-libvirtd:append:x86 = " dmidecode"
 
 #connman blocks the 53 port and libvirtd can't start its DNS service
-RCONFLICTS_${PN}_libvirtd = "connman"
+RCONFLICTS:${PN}_libvirtd = "connman"
 
 SRC_URI = "http://libvirt.org/sources/libvirt-${PV}.tar.xz;name=libvirt \
            file://tools-add-libvirt-net-rpc-to-virt-host-validate-when.patch \
@@ -47,8 +47,8 @@ SRC_URI[libvirt.sha256sum] = "74069438d34082336e99a88146349e21130552b96efc3b7c56
 
 inherit autotools gettext update-rc.d pkgconfig ptest systemd useradd perlnative
 USERADD_PACKAGES = "${PN}"
-GROUPADD_PARAM_${PN} = "-r qemu; -r kvm"
-USERADD_PARAM_${PN} = "-r -g qemu -G kvm qemu"
+GROUPADD_PARAM:${PN} = "-r qemu; -r kvm"
+USERADD_PARAM:${PN} = "-r -g qemu -G kvm qemu"
 
 # Override the default set in autotools.bbclass so that we will use relative pathnames
 # to our local m4 files.  This prevents an "Argument list too long" error during configuration
@@ -109,13 +109,13 @@ CACHED_CONFIGUREVARS += "ac_cv_path_PKCHECK_PATH=${bindir}/pkcheck"
 #ac_cv_path_SCRUB=
 #ac_cv_path_PYTHON=
 
-ALLOW_EMPTY_${PN} = "1"
+ALLOW_EMPTY:${PN} = "1"
 
 PACKAGES =+ "${PN}-libvirtd ${PN}-virsh"
 
-ALLOW_EMPTY_${PN}-libvirtd = "1"
+ALLOW_EMPTY:${PN}-libvirtd = "1"
 
-FILES_${PN}-libvirtd = " \
+FILES:${PN}-libvirtd = " \
 	${sysconfdir}/init.d \
 	${sysconfdir}/sysctl.d \
 	${sysconfdir}/logrotate.d \
@@ -127,12 +127,12 @@ FILES_${PN}-libvirtd = " \
 	${@bb.utils.contains('PACKAGECONFIG', 'gnutls', '${sysconfdir}/pki/libvirt/* ${sysconfdir}/pki/CA/*', '', d)} \
         "
 
-FILES_${PN}-virsh = " \
+FILES:${PN}-virsh = " \
     ${bindir}/virsh \
     ${datadir}/bash-completion/completions/virsh \
 "
 
-FILES_${PN} += "${libdir}/libvirt/connection-driver \
+FILES:${PN} += "${libdir}/libvirt/connection-driver \
 	    ${datadir}/augeas \
 	    ${@bb.utils.contains('PACKAGECONFIG', 'polkit', '${datadir}/polkit-1', '', d)} \
 	    ${datadir}/bash-completion/completions/vsh \
@@ -140,27 +140,27 @@ FILES_${PN} += "${libdir}/libvirt/connection-driver \
 	    /usr/lib/firewalld/zones/libvirt.xml \
 	    "
 
-FILES_${PN}-dbg += "${libdir}/libvirt/connection-driver/.debug ${libdir}/libvirt/lock-driver/.debug"
-FILES_${PN}-staticdev += "${libdir}/*.a ${libdir}/libvirt/connection-driver/*.a ${libdir}/libvirt/lock-driver/*.a"
+FILES:${PN}-dbg += "${libdir}/libvirt/connection-driver/.debug ${libdir}/libvirt/lock-driver/.debug"
+FILES:${PN}-staticdev += "${libdir}/*.a ${libdir}/libvirt/connection-driver/*.a ${libdir}/libvirt/lock-driver/*.a"
 
-CONFFILES_${PN} += "${sysconfdir}/libvirt/libvirt.conf \
+CONFFILES:${PN} += "${sysconfdir}/libvirt/libvirt.conf \
                     ${sysconfdir}/libvirt/lxc.conf \
                     ${sysconfdir}/libvirt/qemu-lockd.conf \
                     ${sysconfdir}/libvirt/qemu.conf \
                     ${sysconfdir}/libvirt/virt-login-shell.conf \
                     ${sysconfdir}/libvirt/virtlockd.conf"
 
-CONFFILES_${PN}-libvirtd = "${sysconfdir}/logrotate.d/libvirt ${sysconfdir}/logrotate.d/libvirt.lxc \
+CONFFILES:${PN}-libvirtd = "${sysconfdir}/logrotate.d/libvirt ${sysconfdir}/logrotate.d/libvirt.lxc \
                             ${sysconfdir}/logrotate.d/libvirt.qemu ${sysconfdir}/logrotate.d/libvirt.uml \
                             ${sysconfdir}/libvirt/libvirtd.conf \
                             /usr/lib/sysctl.d/libvirtd.conf"
 
 INITSCRIPT_PACKAGES = "${PN}-libvirtd"
-INITSCRIPT_NAME_${PN}-libvirtd = "libvirtd"
-INITSCRIPT_PARAMS_${PN}-libvirtd = "defaults 72"
+INITSCRIPT_NAME:${PN}-libvirtd = "libvirtd"
+INITSCRIPT_PARAMS:${PN}-libvirtd = "defaults 72"
 
 SYSTEMD_PACKAGES = "${PN}-libvirtd"
-SYSTEMD_SERVICE_${PN}-libvirtd = " \
+SYSTEMD_SERVICE:${PN}-libvirtd = " \
     libvirtd.service \
     virtlockd.service \
     libvirt-guests.service \
@@ -168,7 +168,7 @@ SYSTEMD_SERVICE_${PN}-libvirtd = " \
     "
 
 
-PRIVATE_LIBS_${PN}-ptest = " \
+PRIVATE_LIBS:${PN}-ptest = " \
 	libvirt-lxc.so.0 \
 	libvirt.so.0 \
 	libvirt-qemu.so.0 \
@@ -198,12 +198,12 @@ PACKAGECONFIG ??= "qemu yajl openvz vmware vbox esx iproute2 lxc test \
                   "
 
 # qemu is NOT compatible with mips64
-PACKAGECONFIG_remove_mipsarchn32 = "qemu"
-PACKAGECONFIG_remove_mipsarchn64 = "qemu"
+PACKAGECONFIG:remove:mipsarchn32 = "qemu"
+PACKAGECONFIG:remove:mipsarchn64 = "qemu"
 
 # numactl is NOT compatible with arm
-PACKAGECONFIG_remove_arm = "numactl"
-PACKAGECONFIG_remove_armeb = "numactl"
+PACKAGECONFIG:remove:arm = "numactl"
+PACKAGECONFIG:remove:armeb = "numactl"
 
 # enable,disable,depends,rdepends
 #
@@ -258,12 +258,12 @@ do_compile() {
 	oe_runmake all
 }
 
-do_install_prepend() {
+do_install:prepend() {
 	# so the install routines can find the libvirt.pc in the source dir
 	export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:${B}/src:"
 }
 
-do_install_append() {
+do_install:append() {
 	install -d ${D}/etc/init.d
 	install -d ${D}/etc/libvirt
 	install -d ${D}/etc/dnsmasq.d
@@ -384,12 +384,12 @@ EXTRA_OECONF += " \
 
 # gcc9 end up mis-compiling qemuxml2argvtest.o with Og which then
 # crashes on target, so remove -Og and use -O2 as workaround
-SELECTED_OPTIMIZATION_remove_virtclass-multilib-lib32_mipsarch = "-Og"
-SELECTED_OPTIMIZATION_append_virtclass-multilib-lib32_mipsarch = " -O2"
+SELECTED_OPTIMIZATION:remove:virtclass-multilib-lib32:mipsarch = "-Og"
+SELECTED_OPTIMIZATION:append:virtclass-multilib-lib32:mipsarch = " -O2"
 
 EXTRA_OEMAKE = "BUILD_DIR=${B} DEST_DIR=${D}${PTEST_PATH} PTEST_DIR=${PTEST_PATH} SYSTEMD_UNIT_DIR=${systemd_system_unitdir}"
 
-PRIVATE_LIBS_${PN}-ptest_append = "libvirt-admin.so.0"
+PRIVATE_LIBS:${PN}-ptest:append = "libvirt-admin.so.0"
 
 do_compile_ptest() {
 	oe_runmake -C tests buildtest-TESTS
@@ -406,7 +406,7 @@ do_install_ptest() {
 	done
 }
 
-pkg_postinst_${PN}() {
+pkg_postinst:${PN}() {
         if [ -z "$D" ] && [ -e /etc/init.d/populate-volatile.sh ] ; then
                 /etc/init.d/populate-volatile.sh update
         fi

--- a/recipes-extended/msmtp/msmtp_%.bbappend
+++ b/recipes-extended/msmtp/msmtp_%.bbappend
@@ -5,7 +5,7 @@ inherit useradd
 
 USERADD_PACKAGES = "${PN}"
 GROUPADD_PACKAGES = "${PN}"
-GROUPADD_PARAM_${PN} = "-g 2000 msmtp"
+GROUPADD_PARAM:${PN} = "-g 2000 msmtp"
 
 do_install:append() {
   install -d ${D}${sysconfdir}/tmpfiles.d

--- a/recipes-extended/packagegroups/packagegroup-core-base-utils.bbappend
+++ b/recipes-extended/packagegroups/packagegroup-core-base-utils.bbappend
@@ -1,7 +1,7 @@
 # Copyright (C) 2021, RTE (http://www.rte-france.com)
 # SPDX-License-Identifier: Apache-2.0
 
-RDEPENDS_${PN}_remove = " \
+RDEPENDS:${PN}:remove = " \
     bind-utils            \
     cpio                  \
     diffutils             \

--- a/recipes-extended/procps/procps_%.bbappend
+++ b/recipes-extended/procps/procps_%.bbappend
@@ -1,9 +1,9 @@
 # Copyright (C) 2021, RTE (http://www.rte-france.com)
 # SPDX-License-Identifier: Apache-2.0
 
-CONFFILES_${PN}_remove = "${sysconfdir}/sysctl.conf"
+CONFFILES:${PN}:remove = "${sysconfdir}/sysctl.conf"
 
-do_install_append() {
+do_install:append() {
     rm -f ${D}${sysconfdir}/sysctl.conf
     rm -f ${D}${sysconfdir}/sysctl.d/99-sysctl.conf
 }

--- a/recipes-extended/shadow/shadow_%.bbappend
+++ b/recipes-extended/shadow/shadow_%.bbappend
@@ -1,13 +1,13 @@
 # Copyright (C) 2021, RTE (http://www.rte-france.com)
 # SPDX-License-Identifier: Apache-2.0
 
-FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 SRC_URI += " \
     file://login.defs \
 "
 
-do_install_append() {
+do_install:append() {
     if ${@bb.utils.contains('DISTRO_FEATURES','seapath-security','true','false',d)}; then
         install -d ${D}${sysconfdir}
         install -m 0644 ${WORKDIR}/login.defs \

--- a/recipes-extended/sudo/sudo_%.bbappend
+++ b/recipes-extended/sudo/sudo_%.bbappend
@@ -1,13 +1,13 @@
 # Copyright (C) 2021, RTE (http://www.rte-france.com)
 # SPDX-License-Identifier: Apache-2.0
 
-FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 SRC_URI += " \
     file://sudoers\
 "
 
-do_install_append() {
+do_install:append() {
     install -d ${D}${sysconfdir}
     install -m 0440 ${WORKDIR}/sudoers \
        ${D}${sysconfdir}/sudoers

--- a/recipes-extended/tuna/tuna_git.bb
+++ b/recipes-extended/tuna/tuna_git.bb
@@ -11,13 +11,13 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0;md5=801f80980d171dd6425
 SRCREV="0681906e75e1c8166126bbfc2f3055e7507bfcb5"
 S="${WORKDIR}/git"
 
-RDEPENDS_${PN} += " \
+RDEPENDS:${PN} += " \
     python3-linux-procfs \
     python3-schedutils \
     python3-inet-diag \
     "
 
-do_install_append() {
+do_install:append() {
     install -m 0755 -d ${D}/${bindir}
     install -m 0755 ${S}/tuna-cmd.py ${D}/${bindir}/tuna
 }

--- a/recipes-kernel/linux/linux-mainline-rt.inc
+++ b/recipes-kernel/linux/linux-mainline-rt.inc
@@ -27,7 +27,7 @@ inherit kernel
 inherit kernel-yocto
 inherit security/deploy-kernelconfig
 
-LINUX_VERSION_EXTENSION_append = "-mainline-rt"
+LINUX_VERSION_EXTENSION:append = "-mainline-rt"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-kernel/linux/linux-mainline-rt_5.15.bb
+++ b/recipes-kernel/linux/linux-mainline-rt_5.15.bb
@@ -14,11 +14,11 @@ SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/rt/linux-stable-rt.git;
         file://megaraid.cfg \
 "
 
-SRC_URI_append_votp-no-iommu = " \
+SRC_URI:append_votp-no-iommu = " \
         file://no-iommu.cfg \
 "
 
 # Uncomment this line to unaible debug traces in Kernel and tracing tools
 # support (like LTTng or perf).
-#SRC_URI_append = " file://traces.cfg"
+#SRC_URI:append = " file://traces.cfg"
 

--- a/recipes-kernel/linux/linux-mainline-rt_6.0.bb
+++ b/recipes-kernel/linux/linux-mainline-rt_6.0.bb
@@ -14,12 +14,12 @@ SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/rt/linux-rt-devel.git;p
         file://megaraid.cfg \
 "
 
-SRC_URI_append_votp-no-iommu = " \
+SRC_URI:append_votp-no-iommu = " \
         file://no-iommu.cfg \
 "
 
 # Uncomment this line to enable debug traces in Kernel and tracing tools
 # support (like LTTng or perf).
-#SRC_URI_append = " file://traces.cfg"
+#SRC_URI:append = " file://traces.cfg"
 
 

--- a/recipes-kernel/lttng/babeltrace2_2.0.2.bb
+++ b/recipes-kernel/lttng/babeltrace2_2.0.2.bb
@@ -25,12 +25,12 @@ EXTRA_OECONF = "--disable-debug-info"
 PACKAGECONFIG ??= "manpages"
 PACKAGECONFIG[manpages] = ", --disable-man-pages, asciidoc-native xmlto-native"
 
-FILES_${PN}-staticdev += "${libdir}/babeltrace2/plugins/*.a"
-FILES_${PN} += "${libdir}/babeltrace2/plugins/*.so"
+FILES:${PN}-staticdev += "${libdir}/babeltrace2/plugins/*.a"
+FILES:${PN} += "${libdir}/babeltrace2/plugins/*.so"
 
 ASNEEDED = ""
 
-RDEPENDS_${PN}-ptest += "bash gawk python3"
+RDEPENDS:${PN}-ptest += "bash gawk python3"
 
 do_compile_ptest () {
     make -C tests all

--- a/recipes-kernel/lttng/lttng-modules_2.11.6.bb
+++ b/recipes-kernel/lttng/lttng-modules_2.11.6.bb
@@ -37,26 +37,26 @@ export INSTALL_MOD_DIR="kernel/lttng-modules"
 
 EXTRA_OEMAKE += "KERNELDIR='${STAGING_KERNEL_DIR}'"
 
-do_install_append() {
+do_install:append() {
 	# Delete empty directories to avoid QA failures if no modules were built
 	if [ -d ${D}/${nonarch_base_libdir} ]; then
 		find ${D}/${nonarch_base_libdir} -depth -type d -empty -exec rmdir {} \;
 	fi
 }
 
-python do_package_prepend() {
+python do_package:prepend() {
     if not os.path.exists(os.path.join(d.getVar('D'), d.getVar('nonarch_base_libdir')[1:], 'modules')):
         bb.warn("%s: no modules were created; this may be due to CONFIG_TRACEPOINTS not being enabled in your kernel." % d.getVar('PN'))
 }
 
 BBCLASSEXTEND = "devupstream:target"
-LIC_FILES_CHKSUM_class-devupstream = "file://LICENSE;md5=3f882d431dc0f32f1f44c0707aa41128"
-DEFAULT_PREFERENCE_class-devupstream = "-1"
-SRC_URI_class-devupstream = "git://git.lttng.org/lttng-modules;branch=stable-2.11 \
+LIC_FILES_CHKSUM:class-devupstream = "file://LICENSE;md5=3f882d431dc0f32f1f44c0707aa41128"
+DEFAULT_PREFERENCE:class-devupstream = "-1"
+SRC_URI:class-devupstream = "git://git.lttng.org/lttng-modules;branch=stable-2.11 \
            file://Makefile-Do-not-fail-if-CONFIG_TRACEPOINTS-is-not-en.patch \
            file://BUILD_RUNTIME_BUG_ON-vs-gcc7.patch \
            "
-SRCREV_class-devupstream = "17c413953603f063f2a9d6c3788bec914ce6f955"
-PV_class-devupstream = "2.11.2+git${SRCPV}"
-S_class-devupstream = "${WORKDIR}/git"
+SRCREV:class-devupstream = "17c413953603f063f2a9d6c3788bec914ce6f955"
+PV:class-devupstream = "2.11.2+git${SRCPV}"
+S:class-devupstream = "${WORKDIR}/git"
 SRCREV_FORMAT ?= "lttng_git"

--- a/recipes-kernel/lttng/lttng-tools_2.11.5.bb
+++ b/recipes-kernel/lttng/lttng-tools_2.11.5.bb
@@ -11,12 +11,12 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=01d7fc4496aacf37d90df90b90b0cac1 \
                     file://lgpl-2.1.txt;md5=0f0d71500e6a57fd24d825f33242b9ca"
 
 DEPENDS = "liburcu popt libxml2 util-linux"
-RDEPENDS_${PN} = "libgcc"
-RDEPENDS_${PN}-ptest += "make perl bash gawk babeltrace procps perl-module-overloading coreutils util-linux kmod lttng-modules sed python3-core"
-RDEPENDS_${PN}-ptest_append_libc-glibc = " glibc-utils"
-RDEPENDS_${PN}-ptest_append_libc-musl = " musl-utils"
+RDEPENDS:${PN} = "libgcc"
+RDEPENDS:${PN}-ptest += "make perl bash gawk babeltrace procps perl-module-overloading coreutils util-linux kmod lttng-modules sed python3-core"
+RDEPENDS:${PN}-ptest:append:libc-glibc = " glibc-utils"
+RDEPENDS:${PN}-ptest:append:libc-musl = " musl-utils"
 # babelstats.pl wants getopt-long
-RDEPENDS_${PN}-ptest += "perl-module-getopt-long"
+RDEPENDS:${PN}-ptest += "perl-module-getopt-long"
 
 PYTHON_OPTION = "am_cv_python_pyexecdir='${PYTHON_SITEPACKAGES_DIR}' \
                  am_cv_python_pythondir='${PYTHON_SITEPACKAGES_DIR}' \
@@ -27,7 +27,7 @@ PACKAGECONFIG[python] = "--enable-python-bindings ${PYTHON_OPTION},,python3 swig
 PACKAGECONFIG[lttng-ust] = "--with-lttng-ust, --without-lttng-ust, lttng-ust"
 PACKAGECONFIG[kmod] = "--with-kmod, --without-kmod, kmod"
 PACKAGECONFIG[manpages] = "--enable-man-pages, --disable-man-pages, asciidoc-native xmlto-native libxslt-native"
-PACKAGECONFIG_remove_arc = "lttng-ust"
+PACKAGECONFIG:remove:arc = "lttng-ust"
 
 SRC_URI = "https://lttng.org/files/lttng-tools/lttng-tools-${PV}.tar.bz2 \
            file://x32.patch \
@@ -42,26 +42,26 @@ SRC_URI[sha256sum] = "38167b49e4d1bf78fdd5c3156d411123713fd8f04b0067d4b1cd03742d
 
 inherit autotools ptest pkgconfig useradd python3-dir manpages systemd
 
-SYSTEMD_SERVICE_${PN} = "lttng-sessiond.service"
+SYSTEMD_SERVICE:${PN} = "lttng-sessiond.service"
 SYSTEMD_AUTO_ENABLE = "disable"
 
 USERADD_PACKAGES = "${PN}"
-GROUPADD_PARAM_${PN} = "tracing"
+GROUPADD_PARAM:${PN} = "tracing"
 
-FILES_${PN} += "${libdir}/lttng/libexec/* ${datadir}/xml/lttng \
+FILES:${PN} += "${libdir}/lttng/libexec/* ${datadir}/xml/lttng \
                 ${PYTHON_SITEPACKAGES_DIR}/*"
-FILES_${PN}-staticdev += "${PYTHON_SITEPACKAGES_DIR}/*.a"
-FILES_${PN}-dev += "${PYTHON_SITEPACKAGES_DIR}/*.la"
+FILES:${PN}-staticdev += "${PYTHON_SITEPACKAGES_DIR}/*.a"
+FILES:${PN}-dev += "${PYTHON_SITEPACKAGES_DIR}/*.la"
 
 # Since files are installed into ${libdir}/lttng/libexec we match 
 # the libexec insane test so skip it.
 # Python module needs to keep _lttng.so
-INSANE_SKIP_${PN} = "libexec dev-so"
-INSANE_SKIP_${PN}-dbg = "libexec"
+INSANE_SKIP:${PN} = "libexec dev-so"
+INSANE_SKIP:${PN}-dbg = "libexec"
 
-PRIVATE_LIBS_${PN}-ptest = "libfoo.so"
+PRIVATE_LIBS:${PN}-ptest = "libfoo.so"
 
-do_install_append () {
+do_install:append () {
     # install systemd unit file
     install -d ${D}${systemd_unitdir}/system
     install -m 0644 ${WORKDIR}/lttng-sessiond.service ${D}${systemd_unitdir}/system

--- a/recipes-kernel/lttng/lttng-ust_2.11.2.bb
+++ b/recipes-kernel/lttng/lttng-ust_2.11.2.bb
@@ -18,12 +18,12 @@ inherit autotools lib_package manpages python3native
 EXTRA_OECONF = "--disable-numa"
 
 DEPENDS = "liburcu util-linux"
-RDEPENDS_${PN}-bin = "python3-core"
+RDEPENDS:${PN}-bin = "python3-core"
 
 # For backwards compatibility after rename
-RPROVIDES_${PN} = "lttng2-ust"
-RREPLACES_${PN} = "lttng2-ust"
-RCONFLICTS_${PN} = "lttng2-ust"
+RPROVIDES:${PN} = "lttng2-ust"
+RREPLACES:${PN} = "lttng2-ust"
+RCONFLICTS:${PN} = "lttng2-ust"
 
 PE = "2"
 
@@ -40,11 +40,11 @@ PACKAGECONFIG[examples] = "--enable-examples, --disable-examples,"
 PACKAGECONFIG[manpages] = "--enable-man-pages, --disable-man-pages, asciidoc-native xmlto-native libxslt-native"
 PACKAGECONFIG[python3-agent] = "--enable-python-agent ${PYTHON_OPTION}, --disable-python-agent, python3, python3"
 
-FILES_${PN} += " ${PYTHON_SITEPACKAGES_DIR}/*"
-FILES_${PN}-staticdev += " ${PYTHON_SITEPACKAGES_DIR}/*.a"
-FILES_${PN}-dev += " ${PYTHON_SITEPACKAGES_DIR}/*.la"
+FILES:${PN} += " ${PYTHON_SITEPACKAGES_DIR}/*"
+FILES:${PN}-staticdev += " ${PYTHON_SITEPACKAGES_DIR}/*.a"
+FILES:${PN}-dev += " ${PYTHON_SITEPACKAGES_DIR}/*.la"
 
-do_install_append() {
+do_install:append() {
         # Patch python tools to use Python 3; they should be source compatible, but
         # still refer to Python 2 in the shebang
         sed -i -e '1s,#!.*python.*,#!${bindir}/python3,' ${D}${bindir}/lttng-gen-tp

--- a/recipes-kvm-unit-tests/kvm-unit-tests/kvm-unit-tests_git.bb
+++ b/recipes-kvm-unit-tests/kvm-unit-tests/kvm-unit-tests_git.bb
@@ -4,7 +4,7 @@
 LICENSE = "GPL-2.0 & LGPL-2.0+"
 LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=8a44f57fb36dd391ae65e11a6d370615"
 HOMEPAGE = "https://www.linux-kvm.org/page/KVM-unit-tests"
-RDEPENDS_${PN} += "bash coreutils glibc-utils python3"
+RDEPENDS:${PN} += "bash coreutils glibc-utils python3"
 
 SRC_URI = " \
 	git://git.kernel.org/pub/scm/virt/kvm/kvm-unit-tests.git \
@@ -41,9 +41,9 @@ do_install () {
 }
 
 
-INSANE_SKIP_${PN} = "arch textrel"
-FILES_${PN} += "${sbindir}/kvm-unit-tests/*"
-FILES_${PN} += "${sbindir}/run_tests.sh"
-FILES_${PN} += "${sbindir}/config.mak"
-FILES_${PN} += "${sbindir}/scripts"
-FILES_${PN} += "${sbindir}/x86"
+INSANE_SKIP:${PN} = "arch textrel"
+FILES:${PN} += "${sbindir}/kvm-unit-tests/*"
+FILES:${PN} += "${sbindir}/run_tests.sh"
+FILES:${PN} += "${sbindir}/config.mak"
+FILES:${PN} += "${sbindir}/scripts"
+FILES:${PN} += "${sbindir}/x86"

--- a/recipes-networking/openvswitch/openvswitch.inc
+++ b/recipes-networking/openvswitch/openvswitch.inc
@@ -16,18 +16,18 @@ LICENSE = "Apache-2"
 
 DEPENDS += "bridge-utils openssl python3 perl python3-six-native coreutils-native"
 
-RDEPENDS_${PN} += "util-linux-uuidgen util-linux-libuuid coreutils \
+RDEPENDS:${PN} += "util-linux-uuidgen util-linux-libuuid coreutils \
         python3 perl perl-module-strict ${PN}-switch \
         bash python3-twisted python3-six"
-RDEPENDS_${PN}-testcontroller = "${PN} ${PN}-pki"
-RDEPENDS_${PN}-switch = "${PN} openssl procps util-linux-uuidgen"
-RDEPENDS_${PN}-pki = "${PN}"
-RDEPENDS_${PN}-brcompat = "${PN} ${PN}-switch"
+RDEPENDS:${PN}-testcontroller = "${PN} ${PN}-pki"
+RDEPENDS:${PN}-switch = "${PN} openssl procps util-linux-uuidgen"
+RDEPENDS:${PN}-pki = "${PN}"
+RDEPENDS:${PN}-brcompat = "${PN} ${PN}-switch"
 
 # Some installers will fail because of an install order based on
 # rdeps.  E.g. ovs-pki calls sed in the postinstall.  sed may be
 # queued for install later.
-RDEPENDS_${PN} += "sed gawk grep"
+RDEPENDS:${PN} += "sed gawk grep"
 
 SRC_URI = "\
 	file://openvswitch-switch \
@@ -48,19 +48,19 @@ CONFIGUREOPT_DEPTRACK = ""
 # distro layers can enable with EXTRA_OECONF_pn_openvswitch += ""
 # EXTRA_OECONF = "--with-linux=${STAGING_KERNEL_DIR} KARCH=${TARGET_ARCH}"
 
-ALLOW_EMPTY_${PN}-pki = "1"
+ALLOW_EMPTY:${PN}-pki = "1"
 PACKAGES =+ "${PN}-testcontroller ${PN}-switch ${PN}-brcompat ${PN}-pki"
 
-FILES_${PN}-testcontroller = "\
+FILES:${PN}-testcontroller = "\
 	${sysconfdir}/init.d/openvswitch-testcontroller \
 	${sysconfdir}/default/openvswitch-testcontroller \
 	${sysconfdir}/openvswitch-testcontroller \
 	${bindir}/ovs-testcontroller \
 	"
 
-FILES_${PN}-brcompat = "${sbindir}/ovs-brcompatd"
+FILES:${PN}-brcompat = "${sbindir}/ovs-brcompatd"
 
-FILES_${PN}-switch = "\
+FILES:${PN}-switch = "\
 	${sysconfdir}/init.d/openvswitch-switch \
 	${sysconfdir}/default/openvswitch-switch \
 	${systemd_unitdir}/system/ovs-vswitchd.service \
@@ -71,33 +71,33 @@ FILES_${PN}-switch = "\
 	"
 
 # silence a warning
-FILES_${PN} += "${datadir}/ovsdbmonitor"
-FILES_${PN} += "/run"
+FILES:${PN} += "${datadir}/ovsdbmonitor"
+FILES:${PN} += "/run"
 
-FILES_${PN} += "${libdir}/python${PYTHON_BASEVERSION}/"
+FILES:${PN} += "${libdir}/python${PYTHON_BASEVERSION}/"
 inherit autotools update-rc.d systemd python3native
 
 SYSTEMD_PACKAGES = "${PN}-switch"
-SYSTEMD_SERVICE_${PN}-switch = " \
+SYSTEMD_SERVICE:${PN}-switch = " \
     ovsdb-server.service \
     ovs-vswitchd.service \
     openvswitch.service \
 "
 
 INITSCRIPT_PACKAGES = "${PN}-switch ${PN}-testcontroller"
-INITSCRIPT_NAME_${PN}-switch = "openvswitch-switch"
-INITSCRIPT_PARAMS_${PN}-switch = "defaults 71"
+INITSCRIPT_NAME:${PN}-switch = "openvswitch-switch"
+INITSCRIPT_PARAMS:${PN}-switch = "defaults 71"
 
-INITSCRIPT_NAME_${PN}-testcontroller = "openvswitch-testcontroller"
-INITSCRIPT_PARAMS_${PN}-testcontroller = "defaults 72"
+INITSCRIPT_NAME:${PN}-testcontroller = "openvswitch-testcontroller"
+INITSCRIPT_PARAMS:${PN}-testcontroller = "defaults 72"
 
-do_configure_prepend() {
+do_configure:prepend() {
 	# Work around the for Makefile CC=$(if ....) by swapping out any
 	# "-Wa," assembly directives with "-Xassembler
 	CC=`echo '${CC}' | sed 's/-Wa,/-Xassembler /g'`
 }
 
-do_install_prepend() {
+do_install:prepend() {
 	SERVICE_FILE="${S}/rhel/usr_lib_systemd_system_ovs-vswitchd.service"
 	${S}/build-aux/dpdkstrip.py \
 	    ${@bb.utils.contains('PACKAGECONFIG','dpdk','--dpdk','--nodpdk',d)} \
@@ -105,7 +105,7 @@ do_install_prepend() {
 	    > ${SERVICE_FILE}
 }
 
-do_install_append() {
+do_install:append() {
 	install -d ${D}/${sysconfdir}/default/
 	install -m 660 ${WORKDIR}/openvswitch-switch-setup ${D}/${sysconfdir}/default/openvswitch-switch
 	install -d ${D}/${sysconfdir}/openvswitch-testcontroller
@@ -140,13 +140,13 @@ do_install_append() {
 	cp -r ${S}/python/ovstest/ ${D}${libdir}/python${PYTHON_BASEVERSION}/site-packages/
 }
 
-pkg_postinst_ontarget_${PN}-pki () {
+pkg_postinst_ontarget:${PN}-pki () {
 	if test ! -d $D/${datadir}/${PN}/pki; then
 		ovs-pki init --dir=$D/${datadir}/${PN}/pki
 	fi
 }
 
-pkg_postinst_ontarget_${PN}-testcontroller () {
+pkg_postinst_ontarget:${PN}-testcontroller () {
 	if test ! -d $D/${datadir}/${PN}/pki; then
 		ovs-pki init --dir=$D/${datadir}/${PN}/pki
 	fi

--- a/recipes-networking/openvswitch/openvswitch_%.bbappend
+++ b/recipes-networking/openvswitch/openvswitch_%.bbappend
@@ -3,7 +3,7 @@
 
 
 DEPENDS += " votp-groups"
-RDEPENDS_${PN} += " \
+RDEPENDS:${PN} += " \
     votp-groups-hugepages \
     votp-groups-vfio-net \
 "
@@ -12,7 +12,7 @@ inherit useradd
 inherit create-dirs
 
 USERADD_PACKAGES = "${PN}"
-USERADD_PARAM_${PN} = " \
+USERADD_PARAM:${PN} = " \
     --system \
     -G hugepages,vfio-net \
     -U openvswitch \
@@ -22,7 +22,7 @@ SERVICE_DIRS_LIST = " openvswitch"
 SERVICE_DIRS_PREFIX = "{log,lib,run}"
 SERVICE_DIRS_OWNER = "openvswitch:openvswitch"
 
-FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 SRC_URI += " \
     file://openvswitch.conf \
@@ -32,7 +32,7 @@ SRC_URI += " \
     file://set-hugepages-permissions.service \
 "
 
-do_install_append()  {
+do_install:append()  {
     install -d ${D}/${sysconfdir}/sysconfig/
     install -m 0644 ${WORKDIR}/openvswitch.conf \
         ${D}${sysconfdir}/sysconfig/openvswitch
@@ -48,10 +48,10 @@ do_install_append()  {
         ${D}/${systemd_unitdir}/system/set-hugepages-permissions.service
 }
 
-SYSTEMD_SERVICE_${PN} += " \
+SYSTEMD_SERVICE:${PN} += " \
     set-hugepages-permissions.service \
 "
 
-FILES_${PN} += " \
+FILES:${PN} += " \
     ${systemd_unitdir}/system/set-hugepages-permissions.service \
 "

--- a/recipes-networking/openvswitch/openvswitch_git.bb
+++ b/recipes-networking/openvswitch/openvswitch_git.bb
@@ -7,7 +7,7 @@ DEPENDS += "virtual/kernel"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
-RDEPENDS_${PN}-ptest += "\
+RDEPENDS:${PN}-ptest += "\
 	python3-logging python3-syslog python3-io python3-core \
 	python3-fcntl python3-shell python3-xml python3-math \
 	python3-datetime python3-netclient python3 sed \
@@ -20,7 +20,7 @@ S = "${WORKDIR}/git"
 PV = "2.15.2+${SRCPV}"
 CVE_VERSION = "2.13.0"
 
-FILESEXTRAPATHS_append := "${THISDIR}/${PN}-git:"
+FILESEXTRAPATHS:append := "${THISDIR}/${PN}-git:"
 
 SRCREV = "63f9a7c5d81e54a3a6fa5ccc2d1b44f6b708979c"
 SRC_URI += "git://github.com/openvswitch/ovs.git;protocol=https;branch=branch-2.15 \
@@ -46,7 +46,7 @@ PACKAGECONFIG[ssl] = ",--disable-ssl,openssl,"
 # EXTRA_OECONF += "--with-linux=${STAGING_KERNEL_BUILDDIR} --with-linux-source=${STAGING_KERNEL_DIR} KARCH=${TARGET_ARCH}"
 
 # silence a warning
-FILES_${PN} += "/lib/modules"
+FILES:${PN} += "/lib/modules"
 
 inherit ptest
 
@@ -56,6 +56,6 @@ do_install_ptest() {
 	oe_runmake test-install
 }
 
-do_install_append() {
+do_install:append() {
 	oe_runmake modules_install INSTALL_MOD_PATH=${D}
 }

--- a/recipes-security/kconfig-hardened-check/kconfig-hardened-check_0.5.9.bb
+++ b/recipes-security/kconfig-hardened-check/kconfig-hardened-check_0.5.9.bb
@@ -13,6 +13,6 @@ S = "${WORKDIR}/git"
 
 BBCLASSEXTEND = "native"
 
-RDEPENDS_${PN} += "python3"
+RDEPENDS:${PN} += "python3"
 
 inherit python3native setuptools3

--- a/recipes-support/openldap/openldap_%.bbappend
+++ b/recipes-support/openldap/openldap_%.bbappend
@@ -1,5 +1,5 @@
 # Copyright (C) 2020, RTE (http://www.rte-france.com)
 # SPDX-License-Identifier: Apache-2.0
 
-PACKAGECONFIG_remove = "gnutls"
-PACKAGECONFIG_append = " openssl sasl"
+PACKAGECONFIG:remove = "gnutls"
+PACKAGECONFIG:append = " openssl sasl"

--- a/recipes-support/swupdate/swupdate_%.bbappend
+++ b/recipes-support/swupdate/swupdate_%.bbappend
@@ -1,9 +1,9 @@
 # Copyright (C) 2021, RTE (http://www.rte-france.com)
 # SPDX-License-Identifier: Apache-2.0
 
-FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
-do_install_append() {
+do_install:append() {
     sed '/\[Service\]/a Environment="LC_ALL=en_US.UTF-8"' -i \
         ${D}${systemd_system_unitdir}/swupdate.service
 }

--- a/recipes-support/syslog-ng/syslog-ng-client.bb
+++ b/recipes-support/syslog-ng/syslog-ng-client.bb
@@ -5,9 +5,9 @@ DESCRIPTION = "Client configuration for syslog-ng"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
 
-RCONFLICTS_${PN} = "syslog-ng-server"
+RCONFLICTS:${PN} = "syslog-ng-server"
 
-FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 SRC_URI += " \
     file://clientcert.pem \
@@ -27,7 +27,7 @@ do_install() {
         ${D}${sysconfdir}/syslog-ng/cert.d
 }
 
-FILES_${PN} += " \
+FILES:${PN} += " \
     ${sysconfdir}/syslog-ng/cert.d/clientcert.pem \
     ${sysconfdir}/syslog-ng/cert.d/clientkey.pem \
     ${sysconfdir}/syslog-ng/syslog-ng.conf \

--- a/recipes-support/syslog-ng/syslog-ng-server.bb
+++ b/recipes-support/syslog-ng/syslog-ng-server.bb
@@ -5,9 +5,9 @@ DESCRIPTION = "Server configuratioin for syslog-ng"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
 
-RCONFLICTS_${PN} = "syslog-ng-client"
+RCONFLICTS:${PN} = "syslog-ng-client"
 
-FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 SRC_URI += " \
     file://servercert.pem \
@@ -27,7 +27,7 @@ do_install() {
         ${D}${sysconfdir}/syslog-ng/cert.d
 }
 
-FILES_${PN} += " \
+FILES:${PN} += " \
     ${sysconfdir}/syslog-ng/cert.d/servercert.pem \
     ${sysconfdir}/syslog-ng/cert.d/serverkey.pem \
     ${sysconfdir}/syslog-ng/syslog-ng.conf \

--- a/recipes-support/syslog-ng/syslog-ng_%.bbappend
+++ b/recipes-support/syslog-ng/syslog-ng_%.bbappend
@@ -8,7 +8,7 @@ DEPENDS += " openssl-native"
 SERVICE_DIRS_LIST += " syslog-ng"
 SERVICE_DIRS_PREFIX = "log"
 
-FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 SRC_URI += " \
     file://cacert.pem \
@@ -16,7 +16,7 @@ SRC_URI += " \
     file://syslog-ng@.service \
 "
 
-do_install_append() {
+do_install:append() {
     rm ${D}${sysconfdir}/${BPN}/syslog-ng.conf
 
     install -d ${D}${sysconfdir}/syslog-ng/ca.d
@@ -36,13 +36,13 @@ do_install_append() {
         ${D}${sysconfdir}/default
 }
 
-CONFFILES_${PN}_remove = "${sysconfdir}/${BPN}.conf"
+CONFFILES:${PN}:remove = "${sysconfdir}/${BPN}.conf"
 
-SYSTEMD_SERVICE_${PN} += " \
+SYSTEMD_SERVICE:${PN} += " \
     syslog-ng@.service \
 "
 
-FILES_${PN} += " \
+FILES:${PN} += " \
     ${sysconfdir}/syslog-ng/ca.d/* \
     ${sysconfdir}/default/syslog-ng@default \
     ${systemd_unitdir}/system/syslog-ng@.service \

--- a/recipes-support/vim/vim-tiny_%.bbappend
+++ b/recipes-support/vim/vim-tiny_%.bbappend
@@ -1,15 +1,15 @@
 # Copyright (C) 2021, RTE (http://www.rte-france.com)
 # SPDX-License-Identifier: Apache-2.0
 
-FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 SRC_URI += " \
     file://vimrc \
 "
 
-do_install_append() {
+do_install:append() {
     install -d ${D}/${datadir}/vim/
     install -m 644 ${WORKDIR}/vimrc ${D}/${datadir}/vim/vimrc
 }
 
-FILES_${PN}_append = " ${datadir}/vim/vimrc"
+FILES:${PN}:append = " ${datadir}/vim/vimrc"

--- a/recipes-tests/test-sync-storage/test-sync-storage_0.1.bb
+++ b/recipes-tests/test-sync-storage/test-sync-storage_0.1.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7ca
 
 inherit pkgconfig cmake systemd
 DEPENDS = "glib-2.0"
-RDEPENDS_${PN} += "bash netcat-openbsd"
+RDEPENDS:${PN} += "bash netcat-openbsd"
 
 PR = "r0"
 S = "${WORKDIR}/"
@@ -20,7 +20,7 @@ SRC_URI = "file://CMakeLists.txt;md5=a832ee3d5087929bd31746f7ff06dcad \
            file://launch_votp_test.sh;md5=4623d2582fc4d15efa8d207c4cdf540e \
 "
 
-do_install_append() {
+do_install:append() {
     install -d ${D}${sysconfdir}/sysconfig/
     install -m 6444 ${S}/votp-test-sync.conf ${D}${sysconfdir}/sysconfig
 
@@ -28,11 +28,11 @@ do_install_append() {
     install -m 0644 ${S}/votp-test-sync.service ${D}${systemd_unitdir}/system/
 }
 
-FILES_${PN} += " \
+FILES:${PN} += " \
     ${sysconfdir}/sysconfig/votp-test-sync.conf \
     ${systemd_unitdir}/system/votp-test-sync.service \
 "
 
-SYSTEMD_SERVICE_${PN} = "votp-test-sync.service"
+SYSTEMD_SERVICE:${PN} = "votp-test-sync.service"
 
-SYSTEMD_AUTO_ENABLE_${PN} = "disable"
+SYSTEMD_AUTO_ENABLE:${PN} = "disable"

--- a/recipes-votp/console-vm-script/console-vm-script.bb
+++ b/recipes-votp/console-vm-script/console-vm-script.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
 
 SRCREV = "${AUTOREV}"
-RDEPENDS_${PN} = "bash"
+RDEPENDS:${PN} = "bash"
 
 SRC_URI = " \
     file://consolevm.sh \
@@ -16,4 +16,4 @@ do_install () {
     install -m 0755 ${WORKDIR}/consolevm.sh ${D}/${bindir}/consolevm
 }
 
-FILES_${PN} = "${bindir}/consolevm"
+FILES:${PN} = "${bindir}/consolevm"

--- a/recipes-votp/flash-script/flash-script.bb
+++ b/recipes-votp/flash-script/flash-script.bb
@@ -5,7 +5,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
 
 SRCREV = "${AUTOREV}"
-RDEPENDS_${PN} = "bash"
+RDEPENDS:${PN} = "bash"
 
 SRC_URI = " \
     file://flash.sh \
@@ -20,5 +20,5 @@ do_install () {
 
 }
 
-FILES_${PN} = "${bindir}/flash"
-FILES_${PN} += "${ROOT_HOME}/.profile"
+FILES:${PN} = "${bindir}/flash"
+FILES:${PN} += "${ROOT_HOME}/.profile"

--- a/recipes-votp/python3-setup-ovs/python3-setup-ovs.bb
+++ b/recipes-votp/python3-setup-ovs/python3-setup-ovs.bb
@@ -1,11 +1,11 @@
 # Copyright (C) 2021, RTE (http://www.rte-france.com)
 # SPDX-License-Identifier: Apache-2.0
 
-FILESEXTRAPATHS_prepend := "${THISDIR}/.:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/.:"
 DESCRIPTION = "A Python3 module to apply an OVS configuration from a JSON file"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
-RDEPENDS_${PN} = "python3 openvswitch python3-pyyaml"
+RDEPENDS:${PN} = "python3 openvswitch python3-pyyaml"
 SRC_URI = "file://src/"
 S = "${WORKDIR}/src"
 inherit setuptools3

--- a/recipes-votp/python3-vm-manager/python3-vm-manager.bb
+++ b/recipes-votp/python3-vm-manager/python3-vm-manager.bb
@@ -4,14 +4,14 @@
 DESCRIPTION = "A Python3 module to manage VMs in a SEAPATH cluster"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
-RDEPENDS_${PN} = "python3 libvirt"
-RDEPENDS_${PN} += "${@bb.utils.contains('DISTRO_FEATURES', 'seapath-clustering', "pacemaker ceph", '', d)}"
+RDEPENDS:${PN} = "python3 libvirt"
+RDEPENDS:${PN} += "${@bb.utils.contains('DISTRO_FEATURES', 'seapath-clustering', "pacemaker ceph", '', d)}"
 SRC_URI = "file://src/"
 S = "${WORKDIR}/src"
-FILESEXTRAPATHS_prepend := "${THISDIR}/.:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/.:"
 inherit setuptools3
 
-do_install_append() {
+do_install:append() {
     # Create testdata directory
     install -d ${D}/${datadir}/testdata
 
@@ -26,4 +26,4 @@ do_install_append() {
     install -D -m 750 ${S}/vm_manager_cmd.py ${D}/${sbindir}/vm-mgr
 }
 
-FILES_${PN} += "${datadir}/testdata/*"
+FILES:${PN} += "${datadir}/testdata/*"

--- a/recipes-votp/system-config/system-config.bb
+++ b/recipes-votp/system-config/system-config.bb
@@ -6,9 +6,9 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
 
 SRCREV = "${AUTOREV}"
-RDEPENDS_${PN}-efi = "bash"
-RDEPENDS_${PN}-security = "bash"
-RDEPENDS_${PN}-host = "python3-setup-ovs openvswitch"
+RDEPENDS:${PN}-efi = "bash"
+RDEPENDS:${PN}-security = "bash"
+RDEPENDS:${PN}-host = "python3-setup-ovs openvswitch"
 
 SRC_URI = " \
     file://common/90-sysctl-hardening.conf \
@@ -92,16 +92,16 @@ SYSTEMD_PACKAGES += " \
     ${PN}-efi \
 "
 
-SYSTEMD_SERVICE_${PN}-common = " \
+SYSTEMD_SERVICE:${PN}-common = " \
     var-log.mount \
 "
 
-SYSTEMD_SERVICE_${PN}-host = " \
+SYSTEMD_SERVICE:${PN}-host = " \
     votp-config_ovs.service \
     hugetlb-gigantic-pages.service \
 "
 
-SYSTEMD_SERVICE_${PN}-efi = " \
+SYSTEMD_SERVICE:${PN}-efi = " \
     swupdate_hawkbit.service \
 "
 
@@ -109,7 +109,7 @@ REQUIRED_DISTRO_FEATURES = "systemd"
 
 inherit allarch systemd features_check
 
-FILES_${PN}-common = " \
+FILES:${PN}-common = " \
     "${@bb.utils.contains('DISTRO_FEATURES','seapath-security',"${sysconfdir}/sysctl.d/90-sysctl-hardening.conf","",d)}" \
     ${sysconfdir}/sysctl.d/99-sysctl-network.conf \
     ${sysconfdir}/profile.d/terminal_idle.sh \
@@ -117,22 +117,22 @@ FILES_${PN}-common = " \
     ${sysconfdir}/vconsole.conf \
 "
 
-FILES_${PN}-host = " \
+FILES:${PN}-host = " \
     ${systemd_unitdir}/system/votp-config_ovs.service \
     ${systemd_unitdir}/system/hugetlb-gigantic-pages.service \
     ${sysconfdir}/modules-load.d/openvswitch.conf \
     ${sbindir}/hugetlb-reserve-pages.sh \
 "
 
-FILES_${PN}-efi = " \
+FILES:${PN}-efi = " \
     ${sysconfdir}/sysconfig/swupdate_hawkbit.conf \
     ${sbindir}/swupdate_hawkbit.sh \
     ${system_unitdir}/system/swupdate_hawkbit.service \
     ${sbindir}/check-health \
 "
 
-FILES_${PN}-security = " \
+FILES:${PN}-security = " \
     ${sbindir}/disable-local-login.sh \
 "
 
-FILES_${PN}-common_append = "${@bb.utils.contains('DISTRO_FEATURES','seapath-readonly', "", " ${base_sbindir}/init.sh", d)}"
+FILES:${PN}-common:append = "${@bb.utils.contains('DISTRO_FEATURES','seapath-readonly', "", " ${base_sbindir}/init.sh", d)}"

--- a/recipes-votp/system-upgrade/system-upgrade.bb
+++ b/recipes-votp/system-upgrade/system-upgrade.bb
@@ -6,7 +6,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
 
 SRCREV = "${AUTOREV}"
-RDEPENDS_${PN} = "bash udev"
+RDEPENDS:${PN} = "bash udev"
 
 SRC_URI = " \
     file://is_from_inactive_bank.sh \
@@ -25,7 +25,7 @@ do_install () {
         ${D}${bindir}/switch_bootloader
 }
 
-FILES_${PN} = " \
+FILES:${PN} = " \
     ${sysconfdir}/udev/rules.d/partition_symlinks.rules \
     ${bindir}/is_from_inactive_bank \
     ${bindir}/switch_bootloader \

--- a/recipes-votp/votp-groups/votp-groups.bb
+++ b/recipes-votp/votp-groups/votp-groups.bb
@@ -19,24 +19,24 @@ USERADD_PACKAGES= " \
     ${PN}-vfio-net \
 "
 
-GROUPADD_PARAM_${PN}-hugepages = "-r hugepages"
-ALLOW_EMPTY_${PN}-hugepages = "1"
+GROUPADD_PARAM:${PN}-hugepages = "-r hugepages"
+ALLOW_EMPTY:${PN}-hugepages = "1"
 
-GROUPADD_PARAM_${PN}-vfio-net = "-r vfio-net"
-ALLOW_EMPTY_${PN}-vfio-net = "1"
+GROUPADD_PARAM:${PN}-vfio-net = "-r vfio-net"
+ALLOW_EMPTY:${PN}-vfio-net = "1"
 
-FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 SRC_URI += " \
     file://host/99-vfio-net.rules \
 "
 
-do_install_append() {
+do_install:append() {
     install -d ${D}${sysconfdir}/udev/rules.d
     install -m 0644 ${WORKDIR}/host/99-vfio-net.rules \
         ${D}${sysconfdir}/udev/rules.d
 }
 
-FILES_${PN}-vfio-net = " \
+FILES:${PN}-vfio-net = " \
     ${sysconfdir}/udev/rules.d/99-vfio-net.rules \
 "


### PR DESCRIPTION
Override syntax changed from Yocto honister 3.4 and have to be adapted to support recent Yocto versions. The current Yocto version dunfell support both syntax versions.