### PR TITLE
dunfell: bbclass: migrate the override syntax to the new syntax

### DIFF
--- a/classes/create-dirs.bbclass
+++ b/classes/create-dirs.bbclass
@@ -1,4 +1,5 @@
 # Copyright (C) 2021, RTE (http://www.rte-france.com)
+# Copyright (C) 2023 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 #
@@ -9,7 +10,7 @@ SERVICE_DIRS_LIST ?= ""
 SERVICE_DIRS_PREFIX ?= ""
 SERVICE_DIRS_OWNER ?= "root:root"
 
-do_install_append() {
+do_install:append() {
   for dir in ${SERVICE_DIRS_LIST}; do
     cat << EOF > ${D}${systemd_unitdir}/system/create-$dir-log-dir.service
 # Copyright (C) 2021, RTE (http://www.rte-france.com)
@@ -37,7 +38,7 @@ python() {
   for dir in dir_list:
     service_name = " create-" + str(dir) + "-log-dir.service"
     service_file = " ${systemd_unitdir}/system/" + service_name[1:]
-    d.appendVar("SYSTEMD_SERVICE_" + d.getVar('PN'), service_name)
-    d.appendVar("FILES_" + d.getVar('PN'), service_file)
+    d.appendVar("SYSTEMD_SERVICE:" + d.getVar('PN'), service_name)
+    d.appendVar("FILES:" + d.getVar('PN'), service_file)
 }
 

--- a/classes/security/check-hardened-compilation.bbclass
+++ b/classes/security/check-hardened-compilation.bbclass
@@ -1,4 +1,5 @@
 # Copyright (C) 2021, RTE (http://www.rte-france.com)
+# Copyright (C) 2023 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 #
@@ -6,7 +7,7 @@
 # hardened compilation and linking options.
 #
 
-DEPENDS_append_class-target = " binutils-native"
+DEPENDS:append:class-target = " binutils-native"
 
 SECCOMPILE_MANIFEST = "${DEPLOY_DIR_IMAGE}/${IMAGE_BASENAME}_disabled_opts.csv"
 SECCOMPILE_MANIFEST_TMP = "${TMPDIR}/disabled_compile_opts"
@@ -103,7 +104,7 @@ do_check_compile_options() {
     :
 }
 
-do_check_compile_options_class-target() {
+do_check_compile_options:class-target() {
     echo "Package name, Package version, binary, missing option" > "${SECCOMPILE_MANIFEST_TMP}"
 
     bbplain "Starting binary compile and linking options analysis..."

--- a/classes/security/users.bbclass
+++ b/classes/security/users.bbclass
@@ -1,4 +1,5 @@
 # Copyright (C) 2021, RTE (http://www.rte-france.com)
+# Copyright (C) 2023 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 #
@@ -20,7 +21,7 @@ GROUPS_LIST_NOPASSWD ?= ""
 GROUPS_LIST_EXEC ?= ""
 SUDO_GROUP_OWNER ?= ""
 
-IMAGE_INSTALL_append = " sudo"
+IMAGE_INSTALL:append = " sudo"
 
 python do_configure_users() {
     import crypt


### PR DESCRIPTION
Override syntax changed from Yocto honister 3.4 and have to be adapted to support recent Yocto versions. The current Yocto version dunfell support both syntax versions.