### PR TITLE
conf/machine/votp-host: "overlay init" only on seapath-overlay

### DIFF
--- a/conf/machine/votp-host.conf
+++ b/conf/machine/votp-host.conf
@@ -7,8 +7,9 @@
 #@DESCRIPTION: Machine configuration for hypervisor compatible with SEAPATH
 
 require conf/machine/votp-machine-common.inc
+
 APPEND += " \
-    init=/sbin/init.sh \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'seapath-overlay', 'init=/sbin/init.sh', '', d)} \
     default_hugepagesz=1G \
     hugepagesz=1G \
     skew_tick=1 \


### PR DESCRIPTION
Add the kernel parameter which enable the "overlay init" only if the DISTRO_FEATURES seapath-overlay is set.