### PR TITLE
recipes-support/vim: add an empty defaults.vim

### DIFF
--- a/recipes-support/vim/vim-tiny_%.bbappend
+++ b/recipes-support/vim/vim-tiny_%.bbappend
@@ -5,11 +5,16 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 SRC_URI += " \
     file://vimrc \
+    file://defaults.vim \
 "
 
 do_install:append() {
     install -d ${D}/${datadir}/vim/
     install -m 644 ${WORKDIR}/vimrc ${D}/${datadir}/vim/vimrc
+    install -m 644 ${WORKDIR}/defaults.vim ${D}/${datadir}/vim/defaults.vim
 }
 
-FILES:${PN}:append = " ${datadir}/vim/vimrc"
+FILES:${PN}:append = " \
+    ${datadir}/vim/vimrc \
+    ${datadir}/vim/defaults.vim \
+"


### PR DESCRIPTION
Without this file vim displays a warning.