### PR TITLE
recipes-votp/system-config: enable RT_RUNTIME_SHARE

### DIFF
--- a/recipes-votp/system-config/system-config.bb
+++ b/recipes-votp/system-config/system-config.bb
@@ -17,8 +17,10 @@ SRC_URI = " \
     file://common/var-log.mount \
     file://cluster/openvswitch.conf \
     file://cluster/votp-config_ovs.service \
+    file://host/enable-rt-runtime-share.sh \
     file://host/hugetlb-gigantic-pages.service \
     file://host/hugetlb-reserve-pages.sh \
+    file://host/rt-runtime-share.service \
     file://efi/swupdate_hawkbit.conf \
     file://efi/swupdate_hawkbit.service \
     file://efi/swupdate_hawkbit.sh \
@@ -68,6 +70,11 @@ do_install () {
     install -m 0755 ${WORKDIR}/host/hugetlb-reserve-pages.sh \
         ${D}/${sbindir}
 
+    install -m 0644 ${WORKDIR}/host/rt-runtime-share.service \
+        ${D}${systemd_unitdir}/system
+    install -m 0755 ${WORKDIR}/host/enable-rt-runtime-share.sh \
+        ${D}/${sbindir}/
+
 # EFI
     install -m 0644 ${WORKDIR}/efi/swupdate_hawkbit.conf \
         ${D}${sysconfdir}/sysconfig
@@ -107,6 +114,7 @@ SYSTEMD_SERVICE:${PN}-cluster = " \
 
 SYSTEMD_SERVICE:${PN}-host = " \
     hugetlb-gigantic-pages.service \
+    rt-runtime-share.service \
 "
 
 SYSTEMD_SERVICE:${PN}-efi = " \
@@ -132,7 +140,9 @@ FILES:${PN}-cluster = " \
 
 FILES:${PN}-host = " \
     ${systemd_unitdir}/system/hugetlb-gigantic-pages.service \
+    ${systemd_unitdir}/system/rt-runtime-share.service \
     ${sbindir}/hugetlb-reserve-pages.sh \
+    ${sbindir}/enable-rt-runtime-share.sh \
 "
 
 FILES:${PN}-efi = " \

--- a/recipes-votp/system-config/system-config/host/enable-rt-runtime-share.sh
+++ b/recipes-votp/system-config/system-config/host/enable-rt-runtime-share.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Copyright (C) 2023 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+echo RT_RUNTIME_SHARE > /sys/kernel/debug/sched/features

--- a/recipes-votp/system-config/system-config/host/rt-runtime-share.service
+++ b/recipes-votp/system-config/system-config/host/rt-runtime-share.service
@@ -1,0 +1,14 @@
+# Copyright (C) 2023 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+[Unit]
+Description=Enable RT_RUNTIME_SHARE
+Before=libvirtd.service
+Before=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/enable-rt-runtime-share.sh
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Enable the "sched_features" RT_RUNTIME_SHARE. When enabled the real time throttling will be calculated with all CPUs and not by CPU. For more information:
https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_for_real_time/7/html/tuning_guide/real_time_throttling