### PR TITLE
recipes-extended/irqbalance: install our irqbalanced.service file

### DIFF
--- a/recipes-extended/irqbalance/files/irqbalanced.service
+++ b/recipes-extended/irqbalance/files/irqbalanced.service
@@ -5,7 +5,7 @@ After=syslog.target
 [Service]
 ExecStartPre=mkdir -p /run/irqbalance
 Environment="IRQBALANCE_BANNED_CPULIST=@RT_CORE_LIST@"
-ExecStart=@SBINDIR@/irqbalance --foreground
+ExecStart=/usr/sbin/irqbalance --foreground
 
 [Install]
 WantedBy=multi-user.target

--- a/recipes-extended/irqbalance/irqbalance_git.bbappend
+++ b/recipes-extended/irqbalance/irqbalance_git.bbappend
@@ -13,6 +13,8 @@ SRC_URI = " \
 "
 
 do_install:append () {
+    install -m 0644 ${WORKDIR}/irqbalanced.service \
+         ${D}${systemd_unitdir}/system/irqbalanced.service
     sed -i -e 's/@RT_CORE_LIST@/${@d.getVar("SEAPATH_RT_CORES", "")}/g' \
         ${D}${systemd_unitdir}/system/irqbalanced.service
 }


### PR DESCRIPTION
Since the Kirkstone migration, our irqbalanced.service file was not installed and all our configuration was ignored.