### PR TITLE
recipes-core/base-passwd: apply poky patches

### DIFF
--- a/recipes-core/base-passwd/base-passwd/group.master
+++ b/recipes-core/base-passwd/base-passwd/group.master
@@ -6,6 +6,7 @@ mail:*:8:
 shadow:*:42:
 utmp:*:43:
 video:*:44:
+kvm:*:47:
 shutdown:*:61
 users:*:100:
 nogroup:*:65534:

--- a/recipes-core/base-passwd/base-passwd/passwd.master
+++ b/recipes-core/base-passwd/base-passwd/passwd.master
@@ -1,5 +1,5 @@
-root:*:0:0:root:/root:/bin/bash
-daemon:*:1:1:daemon:/usr/sbin:/bin/sh
+root::0:0:root:/root:/bin/bash
+daemon:*:1:1:daemon:/usr/sbin:/sbin/nologin
 sync:*:4:65534:sync:/bin:/bin/sync
-mail:*:8:8:mail:/var/mail:/bin/sh
-nobody:*:65534:65534:nobody:/nonexistent:/bin/sh
+mail:*:8:8:mail:/var/mail:/sbin/nologin
+nobody:*:65534:65534:nobody:/nonexistent:/sbin/nologin


### PR DESCRIPTION
By replacing passwd.master and group.master we also bypass poky modifications done by applying patches.

Re-add these modifications directly to the file, except for replacing the root shell by bash (because we have bash in SEAPATH).

The modifications are:
* Use nologin as shell.
* Disable the root password (otherwise, Yocto cannot manage the root password).
* Add group kvm.