### PR TITLE
cukinia: add msmtp group in test

### DIFF
--- a/recipes-cukinia-tests/cukinia-tests/files/hypervisor_security_tests.d/groups.conf
+++ b/recipes-cukinia-tests/cukinia-tests/files/hypervisor_security_tests.d/groups.conf
@@ -32,6 +32,7 @@ groups=" \
     admincluster \
     adminsys \
     emergadmin \
+    msmtp \
     nogroup \
     wheel \
     input \


### PR DESCRIPTION
The group msmtp was missing in cukinia's list of groups.