### PR TITLE
classes/security/hardening: Enable CVE extra exclusions

### DIFF
--- a/classes/security/hardening.inc
+++ b/classes/security/hardening.inc
@@ -13,6 +13,7 @@ require hardening-config.inc
 
 # Community / 3rd-party classes to be included
 inherit cve-check
+include conf/distro/include/cve-extra-exclusions.inc
 inherit image-buildinfo
 inherit create-spdx
 


### PR DESCRIPTION
The Yocto Project maintains a list of CVE exclusions to ignore specific CVEs that are not relevant to the Yocto Project, but are reported nonetheless.

This commit enables that exclusion list.