### PR TITLE
recipes-core/images/seapath-flasher: split into two recipes

### DIFF
--- a/recipes-core/base-files/files/seapath-flash/fstab
+++ b/recipes-core/base-files/files/seapath-flash/fstab
@@ -1,0 +1,5 @@
+/dev/root            /                    auto       defaults              1  1
+proc                 /proc                proc       defaults              0  0
+devpts               /dev/pts             devpts     mode=0620,ptmxmode=0666,gid=5      0  0
+tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,strictatime 0  0
+LABEL=flasher_data   /media               ext4       defaults,ro,nodev,nosuid,noexec 0 0

--- a/recipes-core/images/seapath-flasher-cpio.bb
+++ b/recipes-core/images/seapath-flasher-cpio.bb
@@ -1,0 +1,47 @@
+# Copyright (C) 2020, RTE (http://www.rte-france.com)
+# Copyright (C) 2023 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+DESCRIPTION = "Initramfs image, which can be used by seapath-flasher."
+LICENSE = "Apache-2.0"
+require recipes-core/images/core-image-minimal.bb
+IMAGE_INSTALL:append = " \
+    bmap-tools \
+    e2fsprogs-mke2fs \
+    flash-script \
+    flash-script-auto \
+    python3-json \
+    python3-modules \
+    os-release \
+    kbd-keymaps \
+    efitools \
+    efibootmgr \
+"
+# Add kernel-modules
+IMAGE_INSTALL:append = " \
+    kernel-modules \
+"
+
+IMAGE_INSTALL:append = " openssh-sshd openssh-sftp-server"
+
+IMAGE_INSTALL:append = " less"
+
+GLIBC_GENERATE_LOCALES = "en_US.UTF-8 fr_FR.UTF-8"
+IMAGE_LINGUAS ?= "en_US fr_FR"
+
+PACKAGE_INSTALL = "${IMAGE_INSTALL}"
+INITRAMFS_FSTYPES = "cpio.gz"
+INITRAMFS_IMAGE_BUNDLE = "0"
+
+IMAGE_FSTYPES = "${INITRAMFS_FSTYPES}"
+
+IMAGE_FEATURES += "ssh-server-openssh allow-empty-password empty-root-password"
+EXTRA_IMAGE_FEATURES = ""
+
+USERS_SSH_ANSIBLE = "root"
+
+inherit ansible-ssh
+COMPATIBLE_MACHINE = "votp-flash"
+
+# 256MB
+INITRAMFS_MAXSIZE = "262144"

--- a/recipes-core/images/seapath-flasher.bb
+++ b/recipes-core/images/seapath-flasher.bb
@@ -4,47 +4,29 @@
 
 DESCRIPTION = "An image to flash other SEAPATH images"
 LICENSE = "Apache-2.0"
-require recipes-core/images/core-image-minimal.bb
-IMAGE_INSTALL:append = " \
-    bmap-tools \
-    e2fsprogs-mke2fs \
-    flash-script \
-    flash-script-auto \
-    python3-json \
-    python3-modules \
-    os-release \
-    kbd-keymaps \
-    efitools \
-    efibootmgr \
-"
-# Add kernel-modules
-IMAGE_INSTALL:append = " \
-    kernel-modules \
-"
 
-IMAGE_INSTALL:append = " openssh-sshd openssh-sftp-server"
+inherit image
 
-IMAGE_INSTALL:append = " less"
+IMAGE_FSTYPES = "wic.gz wic.bmap"
 
-GLIBC_GENERATE_LOCALES = "en_US.UTF-8 fr_FR.UTF-8"
-IMAGE_LINGUAS ?= "en_US fr_FR"
+# Note that this recipe does not install any package. It uses the Kernel and the
+# initramfs created in the seapath-flasher-cpio recipe.
+do_image_wic[depends] += "seapath-flasher-cpio:do_image_complete"
+do_configure[noexec] = "1"
+do_compile[noexec] = "1"
+do_install[noexec] = "1"
+deltask do_populate_sysroot
+do_package[noexec] = "1"
+deltask do_package_qa
+do_packagedata[noexec] = "1"
+do_package_write_ipk[noexec] = "1"
+do_package_write_deb[noexec] = "1"
+do_package_write_rpm[noexec] = "1"
+EXCLUDE_FROM_WORLD = "1"
 
-IMAGE_FSTYPES = "${INITRAMFS_FSTYPES} wic.gz wic.bmap"
-
-IMAGE_TYPEDEP:wic = "${INITRAMFS_FSTYPES}"
-IMAGE_FEATURES += "ssh-server-openssh allow-empty-password empty-root-password"
 EXTRA_IMAGE_FEATURES = ""
 
-USERS_SSH_ANSIBLE = "root"
-
-inherit ansible-ssh
 COMPATIBLE_MACHINE = "votp-flash"
-
-PACKAGE_INSTALL = "${IMAGE_INSTALL}"
-INITRAMFS_FSTYPES = "cpio.gz"
-INITRAMFS_IMAGE_BUNDLE = "0"
 
 WKS_FILE = "flasher.wks.in"
 
-# 256MB
-INITRAMFS_MAXSIZE = "262144"

--- a/wic/flasher.wks.in
+++ b/wic/flasher.wks.in
@@ -6,7 +6,7 @@
 # short-description: Create a flasher image
 # long-description: Creates a partitioned disk image that the user
 # can directly dd to boot media.
-part /boot --source bootimg-biosplusefi --sourceparams="loader=${EFI_PROVIDER},title=seapath-flash,label=seapath-flash,initrd=microcode.cpio;${IMAGE_BASENAME}-${MACHINE}.${INITRAMFS_FSTYPES}" --ondisk sda --label flasher --active --align 1024 --use-uuid --fsoptions="defaults,ro"
+part /boot --source bootimg-biosplusefi --sourceparams="loader=${EFI_PROVIDER},title=seapath-flash,label=seapath-flash,initrd=microcode.cpio;${IMAGE_BASENAME}-cpio-${MACHINE}.${INITRAMFS_FSTYPES}" --ondisk sda --label flasher --active --align 1024 --use-uuid --fsoptions="defaults,ro"
 
 part /media --ondisk sda --fstype=ext4 --label flasher_data --align 1024 --use-uuid --size 7G --fsoptions="defaults,ro"
 


### PR DESCRIPTION
To avoid some dependencies issues, split the wic recipe and initramfs recipe into two separate recipes.