### PR TITLE
qemu: enable libusb

### DIFF
--- a/recipes-devtools/qemu/qemu_%.bbappend
+++ b/recipes-devtools/qemu/qemu_%.bbappend
@@ -3,3 +3,5 @@
 
 EXTRA_OECONF:append:class-target = "${@bb.utils.contains('DISTRO_FEATURES','seapath-clustering', " --enable-rbd", "",d)}"
 DEPENDS:append:class-target = "${@bb.utils.contains('DISTRO_FEATURES','seapath-clustering'," ceph", "",d)}"
+
+PACKAGECONFIG:append = " libusb"


### PR DESCRIPTION
This library is used required by qemu to support usb access inside a virtual machine.