### PR TITLE
Openvswitch fixes

### DIFF
--- a/recipes-networking/openvswitch/files/ovs-vswitchd.service
+++ b/recipes-networking/openvswitch/files/ovs-vswitchd.service
@@ -19,7 +19,7 @@ Restart=on-failure
 TimeoutSec=300
 Environment=XDG_RUNTIME_DIR=/run/openvswitch
 LimitSTACK=2M
-ExecStartPre=/usr/libexec/configure_vm_sockets.sh
+ExecStartPre=+/usr/libexec/configure_vm_sockets.sh
 ExecStart=ovs-vswitchd \
     unix:/run/openvswitch/db.sock \
     --mlockall \

--- a/recipes-networking/openvswitch/files/ovs-vswitchd.service
+++ b/recipes-networking/openvswitch/files/ovs-vswitchd.service
@@ -19,7 +19,7 @@ Restart=on-failure
 TimeoutSec=300
 Environment=XDG_RUNTIME_DIR=/run/openvswitch
 LimitSTACK=2M
-ExecPreStart=/usr/libexec/configure_vm_sockets.sh
+ExecStartPre=/usr/libexec/configure_vm_sockets.sh
 ExecStart=ovs-vswitchd \
     unix:/run/openvswitch/db.sock \
     --mlockall \


### PR DESCRIPTION
This PR fixes identified issues with openvswitch package:

- Incorrect syntax used in `recipes-networking/openvswitch/files/ovs-vswitchd.service`
- Missing permission in pre start execution of `/usr/libexec/configure_vm_sockets.sh` in `recipes-networking/openvswitch/files/ovs-vswitchd.service`