### PR TITLE
system-config: fix the conditionnal path for hugetlb-gigantic-pages

### DIFF
--- a/recipes-votp/system-config/system-config/host/hugetlb-gigantic-pages.service
+++ b/recipes-votp/system-config/system-config/host/hugetlb-gigantic-pages.service
@@ -2,7 +2,7 @@
 Description=HugeTLB Gigantic Pages Reservation
 DefaultDependencies=no
 Before=dev-hugepages.mount
-ConditionPathExists=/sys/devices/system/node/hugepages/hugepages-1048576kB
+ConditionPathExists=/sys/devices/system/node/node0/hugepages/hugepages-1048576kB
 ConditionKernelCommandLine=hugepagesz=1G
 
 [Service]


### PR DESCRIPTION
…ervice

The kernel linux create the hugepages directory in the /sys/devices/system/node/node0/ path. The node0 was missing resulting in the run failure of the hugetlb-gigantic-pages service. This commit fix this issue.