### PR TITLE
irqbalance: fix set_irq_max_core.sh script

### DIFF
--- a/recipes-extended/irqbalance/files/set_irq_max_core.sh
+++ b/recipes-extended/irqbalance/files/set_irq_max_core.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-MAX_CPU_CORE=$(($(nproc) - 1))
+MAX_CPU_CORE=$(($(nproc --all) - 1))
 CPU_BAN_LIST=$(grep 'IRQBALANCE_BANNED_CPULIST' /etc/irqbalance.env | awk -F= '{print $2}')
 
 if echo "$CPU_BAN_LIST" | grep -q 'N'; then


### PR DESCRIPTION
The set_irq_max_core.sh script is used to set the maximum core for irqbalance to use. The script uses the nproc command to determine the number of cores on the system. However, the nproc without any options only returns the number of cores available to the current process. This means that the script will not work correctly if the number of cores available to the current process is less than the total number of cores on the system for instance if isolcpus is used.

This patch changes the nproc command to use the --all option to return the total number of cores on the system.

fix #167 