### PR TITLE
recipes-extended/libvirt: add CAP_SYS_RESOURCE to libvirtd.service

### DIFF
--- a/recipes-extended/libvirt/files/libvirtd.service
+++ b/recipes-extended/libvirt/files/libvirtd.service
@@ -60,7 +60,7 @@ ProtectKernelTunables=no
 ProtectControlGroups=no
 RestrictSUIDSGID=true
 RestrictNamespaces=pid user cgroup
-CapabilityBoundingSet=CAP_CHOWN CAP_SYS_NICE CAP_SETUID CAP_SETGID CAP_KILL CAP_DAC_OVERRIDE CAP_NET_ADMIN CAP_FOWNER CAP_NET_BIND_SERVICE CAP_SYS_ADMIN CAP_NET_RAW
+CapabilityBoundingSet=CAP_CHOWN CAP_SYS_NICE CAP_SETUID CAP_SETGID CAP_KILL CAP_DAC_OVERRIDE CAP_NET_ADMIN CAP_FOWNER CAP_NET_BIND_SERVICE CAP_SYS_ADMIN CAP_NET_RAW CAP_SYS_RESOURCE
 ProtectKernelLogs=true
 SystemCallFilter=~@cpu-emulation @aio @clock @module @mount @obsolete @reboot @swap @debug
 


### PR DESCRIPTION
This is required to allow libvirt to perform mlock() and mlockall() system calls and to be able to have PCI passthrough working with QEMU.

Fix #166 