### PR TITLE
kernel_parameters: remove duplicate entries

### DIFF
--- a/conf/machine/votp-machine-common.inc
+++ b/conf/machine/votp-machine-common.inc
@@ -17,6 +17,5 @@ APPEND += " \
     audit=0 \
     slab_nomerge \
     slub_debug=ZF \
-    rootwait \
     rootfstype=ext4 \
 "

--- a/recipes-bsp/grub/files/grub-efi.cfg.in
+++ b/recipes-bsp/grub/files/grub-efi.cfg.in
@@ -34,7 +34,7 @@ menuentry 'active_slot' --unrestricted{
     # Convert device to filesystem identifier
     set sys_part=(${disk},${part}${part_num})
     probe --set sys_part_uuid --part-uuid $sys_part
-    linux /bzImage console=ttyS0,115200 console=tty0 root=PARTUUID=$sys_part_uuid efi=runtime $kernel_parameters
+    linux /bzImage root=PARTUUID=$sys_part_uuid efi=runtime $kernel_parameters
 }
 
 

--- a/recipes-bsp/grub/files/votp-guest/grub-efi.cfg.in
+++ b/recipes-bsp/grub/files/votp-guest/grub-efi.cfg.in
@@ -1,4 +1,4 @@
 default=boot
 menuentry 'boot' --unrestricted{
-linux /bzImage console=ttyS0,115200 console=tty0 root=/dev/vda2 $kernel_parameters
+linux /bzImage root=/dev/vda2 $kernel_parameters
 }


### PR DESCRIPTION
Some kernel parameters are defined by the Yocto project and should not be duplicated in the grub configuration file. This patch removes the duplicate entries from the grub configuration file.

Fix #165 