### PR TITLE
cukinia-tests: fix typo in a test header

### DIFF
--- a/recipes-cukinia-tests/cukinia-tests/files/hypervisor_tests.d/virtualization.conf
+++ b/recipes-cukinia-tests/cukinia-tests/files/hypervisor_tests.d/virtualization.conf
@@ -1,7 +1,7 @@
 # Copyright (C) 2020, RTE (http://www.rte-france.com)
 # SPDX-License-Identifier: Apache-2.0
 
-cukinia_log "$(_colorize yellow "--- heck that the virtualization can run ---")"
+cukinia_log "$(_colorize yellow "--- check that the virtualization can run ---")"
 as "SEAPATH-00018 - KVM device available" cukinia_test -c /dev/kvm
 as "SEAPATH-00019 - Qemu for x86-64 available" cukinia_cmd qemu-system-x86_64 --version
 as "SEAPATH-00020 - Libvirtd service is running" cukinia_cmd systemctl is-active libvirtd


### PR DESCRIPTION
Fix the typo in the virtualization.conf header.