### PR TITLE
seapath-host-common.inc: add chrony and chronyc

### DIFF
--- a/recipes-core/images/seapath-host-common.inc
+++ b/recipes-core/images/seapath-host-common.inc
@@ -28,6 +28,8 @@ IMAGE_INSTALL:append = " \
     python3-vm-manager \
     tuna \
     irqbalance \
+    chrony \
+    chronyc \
 "
 
 IMAGE_INSTALL:append = " cukinia-tests-hypervisor-iommu"


### PR DESCRIPTION
Add chrony and chronyc to the host image.