### PR TITLE
system-config: split security and readonly features

### DIFF
--- a/recipes-core/images/seapath-guest-common.inc
+++ b/recipes-core/images/seapath-guest-common.inc
@@ -1,4 +1,5 @@
 # Copyright (C) 2022, RTE (http://www.rte-france.com)
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 DESCRIPTION = "A common base for guest image"
@@ -10,7 +11,8 @@ inherit ${@bb.utils.contains('DISTRO_FEATURES', 'seapath-security', 'security/qa
 IMAGE_INSTALL:append = " \
     cukinia-tests-vm \
     syslog-ng-client \
-    system-config-security \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'seapath-security', 'system-config-security', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'seapath-readonly', 'system-config-ro', '', d)} \
     net-snmp-server \
     net-snmp-client \
     net-snmp-dev \

--- a/recipes-core/images/seapath-host-common.inc
+++ b/recipes-core/images/seapath-host-common.inc
@@ -1,4 +1,5 @@
 # Copyright (C) 2022, RTE (http://www.rte-france.com)
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 DESCRIPTION = "A production image for Seapath"
@@ -21,6 +22,7 @@ IMAGE_INSTALL:append = " \
     system-config-host \
     system-config-cluster \
     ${@bb.utils.contains('DISTRO_FEATURES', 'seapath-security', 'system-config-security', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'seapath-readonly', 'system-config-ro', '', d)} \
     system-upgrade \
     net-snmp-server \
     net-snmp-client \

--- a/recipes-core/images/seapath-monitor-common.inc
+++ b/recipes-core/images/seapath-monitor-common.inc
@@ -1,4 +1,5 @@
 # Copyright (C) 2022, RTE (http://www.rte-france.com)
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 USERS_LIST_LOCKED:remove = "qemu"
@@ -7,6 +8,8 @@ IMAGE_INSTALL:append = " \
     cukinia-tests-monitor \
     system-upgrade \
     system-config-cluster \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'seapath-security', 'system-config-security', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'seapath-readonly', 'system-config-ro', '', d)} \
 "
 
 COMPATIBLE_MACHINE = "votp-monitor"


### PR DESCRIPTION
Create a new package system-config-ro to handle the read-only feature instead of using the system-config-common package with a distro feature.

Move all the security related files which were in the system-config-common package to the system-config-security package.

Update the image recipes accordingly.