### PR TITLE
flash-script: extend persistent part to all space

### DIFF
--- a/recipes-votp/flash-script/files/flash.sh
+++ b/recipes-votp/flash-script/files/flash.sh
@@ -91,6 +91,25 @@ else
     exit 1
 fi
 
+# Check if GPT headers are well placed at the end of the disk
+GPT_ISSUES=$(sgdisk -v $disk|grep Identified|cut -d' ' -f2)
+
+# And fix them if not
+if [ "$GPT_ISSUES" -ge 0 ]; then
+    echo "Fix GPT headers"
+    sgdisk -e $disk
+fi
+
+# Extend persistent partition to fit all the available space
+echo "Extend data partition to remaining free space"
+END=$(parted "$disk" -s unit s print free | grep 'Free Space' | tail -n1 | awk '{print $2}')
+LAST_PART=$(fdisk -l ${disk} | grep '^/dev' | tail -n1 | awk -F' ' '{print $1}' | grep -o '[0-9]*$')
+parted -s -- "${disk}" resizepart "${LAST_PART}" "${END}"
+
+# Update file system
+echo "Update file system to the new partition size"
+resize2fs "${disk}""${LAST_PART}"
+
 # If EFI image create boot entries
 if command -v efibootmgr &> /dev/null && efibootmgr &> /dev/null ; then
 

--- a/recipes-votp/flash-script/flash-script.bb
+++ b/recipes-votp/flash-script/flash-script.bb
@@ -10,7 +10,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
 
 SRCREV = "${AUTOREV}"
-RDEPENDS:${PN} = "bash"
+RDEPENDS:${PN} = "bash e2fsprogs-resize2fs gptfdisk parted"
 
 PACKAGES += "${PN}-auto"
 


### PR DESCRIPTION
Currently, size of the persistent partition is set by the WIC file. The problem is if we want a bigger partition size, it will make final WIC image bigger too, even if it contains no data.
To resolve this, this commit extends during flash the size of the persistent partition to maximum freespace available on the disk.