### PR TITLE
cockpit: remove occurences of machine package

### DIFF
--- a/recipes-webadmin/cockpit/cockpit_304.bb
+++ b/recipes-webadmin/cockpit/cockpit_304.bb
@@ -60,7 +60,6 @@ PACKAGES =+ " \
     ${PN}-sosreport \
     ${PN}-storaged \
     ${PN}-networkmanager \
-    ${PN}-machines \
     ${PN}-selinux \
     ${PN}-playground \
     ${PN}-docker \
@@ -103,10 +102,6 @@ FILES:${PN}-networkmanager = " \
 "
 RDEPENDS:${PN}-networkmanager = "networkmanager"
 
-FILES:${PN}-machines = " \
-    ${datadir}/cockpit/machines \
-    ${datadir}/metainfo/org.cockpit-project.cockpit-machines.metainfo.xml \
-"
 FILES:${PN}-selinux = " \
     ${datadir}/cockpit/selinux \
     ${datadir}/metainfo/org.cockpit-project.cockpit-selinux.metainfo.xml \


### PR DESCRIPTION
Since Cockpit version 242, `cockpit-machines` has been moved in a dedicated repository. So it is not needed anymore to keep the old cockpit-machines package in the cockpit recipe.