### PR TITLE
seapath-flasher: install amdgpu firmwares

### DIFF
--- a/recipes-core/images/seapath-flasher-cpio.bb
+++ b/recipes-core/images/seapath-flasher-cpio.bb
@@ -16,6 +16,7 @@ IMAGE_INSTALL:append = " \
     kbd-keymaps \
     efitools \
     efibootmgr \
+    linux-firmware-amdgpu \
 "
 # Add kernel-modules
 IMAGE_INSTALL:append = " \
@@ -44,4 +45,4 @@ inherit ansible-ssh
 COMPATIBLE_MACHINE = "votp-flash"
 
 # 256MB
-INITRAMFS_MAXSIZE = "262144"
+INITRAMFS_MAXSIZE = "400000"


### PR DESCRIPTION
Since commit 685723440a55010d7fb7c274cd1f831098f546c9 amdgpu firmwares are needed to avoid a stucking boot with Seapath installer. As binaries are added into initramfs image, this commit increases the maximum size to 400Mb.