### PR TITLE
swupdate_install: remove swupdate logs

### DIFF
--- a/recipes-core/images/files/swupdate_install.sh
+++ b/recipes-core/images/files/swupdate_install.sh
@@ -13,6 +13,14 @@ do_preinst()
 {
     echo "Pre-Install:"
 
+    if [ -f /var/log/update_success ]; then
+        rm -f /var/log/update_success
+    fi
+
+    if [ -f /var/log/update_failure ]; then
+        rm -f /var/log/update_failure
+    fi
+
     if [ ! -L "/dev/upgradable_bootloader" ] ; then
         die "Could not find symbolic link /dev/upgradable_bootloader"
     fi


### PR DESCRIPTION
This commit remove the logs of the previous update to detect the success or the failure of the current one.