### PR TITLE
classes/ansible-ssh: add python3-lxml dependency

### DIFF
--- a/classes/ansible-ssh.bbclass
+++ b/classes/ansible-ssh.bbclass
@@ -9,6 +9,8 @@
 AUTHORIZED_KEYS_DIR := "${THISDIR}/ansible"
 USERS_SSH_ANSIBLE ?= ""
 USERS_SSH_ANSIBLE[doc] = "List of the users allowed to connect through SSH using Ansible keys"
+# Newer Ansible dependencies
+IMAGE_INSTALL:append = " python3-lxml"
 
 do_add_ansible_ssh_key() {
     export PSEUDO="${FAKEROOTENV} ${STAGING_DIR_NATIVE}${bindir}/pseudo"


### PR DESCRIPTION
Newer Ansible versions require python3-lxml to use the xml module. Add this dependency to the image when using the ansible-ssh class.