### PR TITLE
images/seapath-common: add Netplan to images

### DIFF
--- a/recipes-core/images/seapath-common.inc
+++ b/recipes-core/images/seapath-common.inc
@@ -10,6 +10,7 @@ IMAGE_INSTALL:append = " \
     cukinia-tests-common \
     ${@bb.utils.contains('DISTRO_FEATURES','seapath-security','cukinia-tests-common-security','',d)} \
     linuxptp \
+    netplan \
     system-config-common \
 "
 # Add kernel-modules


### PR DESCRIPTION
Netplan is a utility for configuring networking on Linux systems. SEAPATH now use it to configure network interfaces.