### PR TITLE
seapath-monitor-common.inc: install chrony on monitor

### DIFF
--- a/recipes-core/images/seapath-monitor-common.inc
+++ b/recipes-core/images/seapath-monitor-common.inc
@@ -10,6 +10,8 @@ IMAGE_INSTALL:append = " \
     system-config-cluster \
     ${@bb.utils.contains('DISTRO_FEATURES', 'seapath-security', 'system-config-security', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'seapath-readonly', 'system-config-ro', '', d)} \
+    chrony \
+    chronyc \
 "
 
 COMPATIBLE_MACHINE = "seapath-monitor"


### PR DESCRIPTION
Timemaster is currently installed on both hosts and observers, but chrony is only installed on hosts.
To make uniform which tools are used for PTP and NTP among machines in a cluster, also install chrony and chronyc on the observer machine. That way, the same timemaster/chrony configuration can be used for all machines in a cluster.