### PR TITLE
flash-script: refactor disk path

### DIFF
--- a/recipes-seapath/flash-script/files/auto-flash.sh.in
+++ b/recipes-seapath/flash-script/files/auto-flash.sh.in
@@ -23,7 +23,7 @@ case "$1" in
 
     echo "Mounting the flash partition and flashing seapath.wic.gz on ${disk}"
     mount /dev/disk/by-label/flasher_data -o ro /mnt/
-    flash -i /mnt/seapath.wic.gz -d "/dev/${disk}"
+    flash -i /mnt/seapath.wic.gz -d "${disk}"
 
     echo "Moving the current boot entry (USB boot) at the end of the bootorder"
     current_boot=$(efibootmgr |grep BootCurrent |grep -Eo '[0-9]+')

--- a/recipes-seapath/flash-script/flash-script.bb
+++ b/recipes-seapath/flash-script/flash-script.bb
@@ -30,7 +30,7 @@ do_install () {
     install -d ${D}${sysconfdir}/init.d
     install -m 0755 ${WORKDIR}/auto-flash.sh.in \
         ${D}${sysconfdir}/init.d/auto-flash.sh
-    sed "s/@@SEAPATH_AUTO_FLASH@@/${SEAPATH_AUTO_FLASH}/" -i \
+    sed "s|@@SEAPATH_AUTO_FLASH@@|${SEAPATH_AUTO_FLASH}|" -i \
         ${D}${sysconfdir}/init.d/auto-flash.sh
 }
 


### PR DESCRIPTION
Refactor the sed command to be able to include / and : in the disk path. Also remove the `/dev` in the script. The disk path must now include it.