### PR TITLE
ceph-mgr fixes

### DIFF
--- a/recipes-extended/ceph/ceph_%.bbappend
+++ b/recipes-extended/ceph/ceph_%.bbappend
@@ -1,8 +1,16 @@
+# Copyright (C) 2022-2024 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
 inherit useradd
 
 USERADD_PACKAGES= "${PN}"
 USERADD_PARAM:${PN} = "--system --no-create-home --home-dir /var/lib/ceph \
     --shell /bin/nologin --user-group -c 'Ceph daemons' ceph"
+
+
+SRC_URI += "file://0001-mgr-Define-PY_SSIZE_T_CLEAN-ahead-of-every-Python.h.patch"
 
 EXTRA_OECMAKE = "-DWITH_MANPAGE=OFF \
                  -DWITH_FUSE=OFF \

--- a/recipes-extended/ceph/ceph_%.bbappend
+++ b/recipes-extended/ceph/ceph_%.bbappend
@@ -22,6 +22,25 @@ EXTRA_OECMAKE = "-DWITH_MANPAGE=OFF \
                  -DWITH_RADOSGW_KAFKA_ENDPOINT=OFF \
 "
 
+PACKAGE_BEFORE_PN = "\
+    ${PN}-mgr-dashboard \
+    ${PN}-mgr-restful \
+    ${PN}-mgr-cephadm \
+    ${PN}-mgr-prometheus \
+    ${PN}-mgr-rook \
+    ${PN}-mgr-zabbix \
+    ${PN}-mgr-telegraf \
+    ${PN}-mgr-influx \
+    ${PN}-mgr-alert \
+    ${PN}-mgr-diskprediction_cloud \
+    ${PN}-mgr-insights \
+    ${PN}-mgr-k8sevents \
+    ${PN}-mgr-localpool \
+    ${PN}-mgr-osd_support \
+    ${PN}-mgr-selftest \
+    ${PN}-mgr-test_orchestrator \
+"
+
 def limit_parallel(d):
     import multiprocessing
     return "-j{}".format(d.getVar("SEAPATH_PARALLEL_MAKE", multiprocessing.cpu_count()))
@@ -59,8 +78,105 @@ do_install:append:class-target () {
         fi
 }
 
+FILES:${PN}-mgr-dashboard = "${datadir}/ceph/mgr/dashboard"
+FILES:${PN}-mgr-restful = "${datadir}/ceph/mgr/restful"
+FILES:${PN}-mgr-cephadm = "${datadir}/ceph/mgr/cephadm"
+FILES:${PN}-mgr-prometheus = "${datadir}/ceph/mgr/prometheus"
+FILES:${PN}-mgr-rook = "${datadir}/ceph/mgr/rook"
+FILES:${PN}-mgr-zabbix = "${datadir}/ceph/mgr/zabbix"
+FILES:${PN}-mgr-telegraf = "${datadir}/ceph/mgr/telegraf"
+FILES:${PN}-mgr-influx = "${datadir}/ceph/mgr/influx"
+FILES:${PN}-mgr-alert = "${datadir}/ceph/mgr/alert"
+FILES:${PN}-mgr-diskprediction_cloud = "${datadir}/ceph/mgr/diskprediction_cloud"
+FILES:${PN}-mgr-insights = "${datadir}/ceph/mgr/insights"
+FILES:${PN}-mgr-k8sevents = "${datadir}/ceph/mgr/k8sevents"
+FILES:${PN}-mgr-localpool = "${datadir}/ceph/mgr/localpool"
+FILES:${PN}-mgr-osd_support = "${datadir}/ceph/mgr/osd_support"
+FILES:${PN}-mgr-selftest = "${datadir}/ceph/mgr/selftest"
+FILES:${PN}-mgr-test_orchestrator = "${datadir}/ceph/mgr/test_orchestrator"
+
 RDEPENDS:${PN} += "\
 		python3-dateutil \
 		python3-requests \
 		lvm2 \
 "
+
+RDEPENDS:${PN}-mgr-dashboard = "${PN}-mgr-restful" 
+
+RDEPENDS:${PN}-mgr-restful = "\
+        ${PN} \
+        ${PN}-python \
+"
+
+RDEPENDS:${PN}-mgr-cephadm = "\
+        ${PN} \
+        ${PN}-python \
+        python3-jinja2 \
+"
+
+RDEPENDS:${PN}-mgr-prometheus = "\
+        ${PN} \
+        ${PN}-python \
+"
+
+RDEPENDS:${PN}-mgr-rook = "\
+        ${PN} \
+        ${PN}-python \
+        python3-jsonpatch \
+"
+
+RDEPENDS:${PN}-mgr-zabbix = "\
+        ${PN} \
+        ${PN}-python \
+"
+
+RDEPENDS:${PN}-mgr-telegraf = "\
+        ${PN} \
+        ${PN}-python \
+"
+
+RDEPENDS:${PN}-mgr-influx = "\
+        ${PN} \
+        ${PN}-python \
+"
+
+RDEPENDS:${PN}-mgr-alert = "\
+        ${PN} \
+        ${PN}-python \
+"
+
+RDEPENDS:${PN}-mgr-diskprediction_cloud = "\
+        ${PN} \
+        ${PN}-python \
+"
+
+RDEPENDS:${PN}-mgr-insights = "\
+        ${PN} \
+        ${PN}-python \
+"
+
+RDEPENDS:${PN}-mgr-k8sevents = "\
+        ${PN} \
+        ${PN}-python \
+"
+
+RDEPENDS:${PN}-mgr-localpool = "\
+        ${PN} \
+        ${PN}-python \
+"
+
+RDEPENDS:${PN}-mgr-osd_support = "\
+        ${PN} \
+        ${PN}-python \
+"
+
+RDEPENDS:${PN}-mgr-selftest = "\
+        ${PN} \
+        ${PN}-python \
+"
+
+RDEPENDS:${PN}-mgr-test_orchestrator = "\
+        ${PN} \
+        ${PN}-python \
+"
+

--- a/recipes-extended/ceph/files/0001-mgr-Define-PY_SSIZE_T_CLEAN-ahead-of-every-Python.h.patch
+++ b/recipes-extended/ceph/files/0001-mgr-Define-PY_SSIZE_T_CLEAN-ahead-of-every-Python.h.patch
@@ -1,0 +1,38 @@
+From 389054888f2aa782f73564125ec7a1ef0212d536 Mon Sep 17 00:00:00 2001
+From: Pete Zaitcev <zaitcev@redhat.com>
+Date: Tue, 14 Dec 2021 23:04:34 -0600
+Subject: [PATCH] mgr: Define PY_SSIZE_T_CLEAN ahead of every Python.h
+
+Building on Fedora 35 with Python 3.10 makes vstart to loop
+forever, throwing the following message:
+
+ Error EINVAL: SystemError: PY_SSIZE_T_CLEAN macro must be
+ defined for '#' formats
+
+I followed the hint in the following document:
+ https://docs.python.org/3/c-api/intro.html
+
+It says "recommended" to always define PY_SSIZE_T_CLEAN,
+but as you can see it is actually required in our case.
+
+Fixes: https://tracker.ceph.com/issues/53441
+Signed-off-by: Pete Zaitcev <zaitcev@redhat.com>
+---
+ src/mgr/CMakeLists.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/mgr/CMakeLists.txt b/src/mgr/CMakeLists.txt
+index 55147af4fc6..8f39e41ac06 100644
+--- a/src/mgr/CMakeLists.txt
++++ b/src/mgr/CMakeLists.txt
+@@ -30,6 +30,7 @@
+     mgr_commands.cc
+     $<TARGET_OBJECTS:mgr_cap_obj>)
+   add_executable(ceph-mgr ${mgr_srcs})
++  target_compile_definitions(ceph-mgr PRIVATE PY_SSIZE_T_CLEAN)
+   target_link_libraries(ceph-mgr
+     osdc client heap_profiler
+     global-static ceph-common
+-- 
+2.45.2
+


### PR DESCRIPTION
* Separate ceph-mgr plugins into packages and install only the wanted plugins.
* Backport the PY_SSIZE_T_CLEAN fix