### PR TITLE
pacekamer: add remote resource agent to pacemaker package

### DIFF
--- a/recipes-cgl/pacemaker/pacemaker_%.bbappend
+++ b/recipes-cgl/pacemaker/pacemaker_%.bbappend
@@ -36,3 +36,10 @@ FILES:${PN} += " \
     ${systemd_unitdir}/system/create-var-run-resource-agents.service \
     ${systemd_unitdir}/system/pacemaker.service \
 "
+
+# The remote ressource agent should be packaged in pacemaker package with the
+# other resource agents
+FILES:${PN}-remote:remove = "${libdir}/ocf/resource.d/pacemaker/remote"
+FILES:${PN}:append = "${libdir}/ocf/resource.d/pacemaker/remote"
+
+


### PR DESCRIPTION
The remote resource agent is not packaged in the pacemaker package. This patch adds the remote resource agent to the pacemaker package.