### PR TITLE
cluster-resource-agents: remove obsolete SRC_URI fix

### DIFF
--- a/recipes-cgl/cluster-resource-agents/resource-agents_4.5.0.bbappend
+++ b/recipes-cgl/cluster-resource-agents/resource-agents_4.5.0.bbappend
@@ -5,8 +5,6 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 SRC_URI += "file://VirtualDomain"
-SRC_URI:remove = "git://github.com/ClusterLabs/resource-agents"
-SRC_URI += "git://github.com/ClusterLabs/resource-agents;nobranch=1;protocol=https"
 
 REQUIRED_HEARTBEAT_SCRIPTS = "VirtualDomain"
 


### PR DESCRIPTION
In meta-cgl, commit [1] fixed the missing branch and protocol fields in SRC_URI, and commit [2] update the branch name from master to main. Thus, the SRC_URI fix is not needed anymore.

[1]: https://git.yoctoproject.org/meta-cgl/commit/?id=d5299ea2f3c15d482621f1ea4474f583620724a1
[2]: https://git.yoctoproject.org/meta-cgl/commit/?id=162730c253796c9d494891978d334514897cf395