### PR TITLE
recipes-core/images: add host EFI test .swu image

### DIFF
--- a/recipes-core/images/seapath-host-efi-test-swu-image.bb
+++ b/recipes-core/images/seapath-host-efi-test-swu-image.bb
@@ -1,0 +1,24 @@
+# Copyright (C) 2021, RTE (http://www.rte-france.com)
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+DESCRIPTION = "SWUpdate upgrade test image for SEAPATH"
+LICENSE = "Apache-2.0"
+FILESEXTRAPATHS:prepend := "${THISDIR}/files/hosts:"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+inherit swupdate
+
+SRC_URI = "\
+    file://sw-description \
+    file://swupdate_install.sh \
+"
+
+# Images to build before building SWUpdate image
+IMAGE_DEPENDS = "seapath-host-efi-test-image"
+
+# Images and files that will be included in the .swu image
+SWUPDATE_IMAGES = "seapath-host-efi-test-image seapath-host-efi-test-image-boot"
+
+SWUPDATE_IMAGES_FSTYPES[seapath-host-efi-test-image] = ".tar.xz"
+SWUPDATE_IMAGES_FSTYPES[seapath-host-efi-test-image-boot] = ".tar.xz"


### PR DESCRIPTION
Generate a SWUpdate image to update EFI hosts. This image is derived from the swu image of the host's EFI model.