### PR TITLE
system-config: fix the use of system-config-test

### DIFF
--- a/recipes-seapath/system-config/system-config.bb
+++ b/recipes-seapath/system-config/system-config.bb
@@ -84,6 +84,7 @@ PACKAGES =+ " \
     ${PN}-security \
     ${PN}-cluster \
     ${PN}-ro \
+    ${PN}-test \
 "
 SYSTEMD_PACKAGES += " \
     ${PN}-common \


### PR DESCRIPTION
The system-config-test package had been declared but not added to the PACKAGES variable. The test image using this package to enable the CDC_ACM module could therefore not be built.