### PR TITLE
Cockpit-machine: add osinfo database and configure libvirt-dbus

### DIFF
--- a/conf/distro/seapath-common.inc
+++ b/conf/distro/seapath-common.inc
@@ -24,7 +24,7 @@ DISTRO_FEATURES:remove = " wayland"
 
 # Remove unneeded distribution features
 DISTRO_FEATURES:remove = " 3g alsa bluetooth nfc nfs opengl pcmcia vulkan wifi zeroconf"
-DISTRO_FEATURES_BACKFILL_CONSIDERED += "pulseaudio gobject-introspection-data"
+DISTRO_FEATURES_BACKFILL_CONSIDERED += "pulseaudio"
 
 # Active buildhistory
 INHERIT += "buildhistory"

--- a/recipes-extended/libvirt/libvirt-dbus_1.4.1.bb
+++ b/recipes-extended/libvirt/libvirt-dbus_1.4.1.bb
@@ -20,6 +20,8 @@ S = "${WORKDIR}/git"
 
 inherit meson pkgconfig
 
+EXTRA_OEMESON += "-Dsystem_user=root -Dunix_socket_group=qemu"
+
 FILES:${PN} += "\
     ${datadir}/dbus-1/* \
     ${datadir}/polkit-1/* \

--- a/recipes-extended/virt-manager/virt-manager_4.1.0.bb
+++ b/recipes-extended/virt-manager/virt-manager_4.1.0.bb
@@ -31,8 +31,14 @@ RDEPENDS:${PN}-common += " \
   libosinfo \
 "
 
-RDEPENDS:${PN} = "${PN}-common"
-RDEPENDS:${PN}-install = "${PN}-common"
+RDEPENDS:${PN} = " \
+  ${PN}-common \
+  libvirt-glib \
+  libxml2-python \
+  python3-pygobject \
+  python3-requests \
+"
+RDEPENDS:${PN}-install = "${PN}"
 
 SETUPTOOLS_INSTALL_ARGS += "${PACKAGECONFIG_CONFARGS}"
 

--- a/recipes-support/libosinfo/libosinfo_1.11.0.bb
+++ b/recipes-support/libosinfo/libosinfo_1.11.0.bb
@@ -35,4 +35,4 @@ EXTRA_OEMESON += " \
 	-Dwith-usb-ids-path=${datadir}/hwdata/usb.ids \
 "
 
-RDEPENDS:${PN} = "hwdata"
+RDEPENDS:${PN} = "hwdata osinfo-db"

--- a/recipes-support/libosinfo/osinfo-db-tools/0001-Make-xmlError-structs-constant.patch
+++ b/recipes-support/libosinfo/osinfo-db-tools/0001-Make-xmlError-structs-constant.patch
@@ -1,0 +1,56 @@
+Upstream-Status: Backport [https://gitlab.com/libosinfo/osinfo-db-tools/-/commit/34378a4]
+
+Signed-off-by: Kai Kang <kai.kang@windriver.com>
+
+From 34378a4ac257f2f5fcf364786d1634a8c36b304f Mon Sep 17 00:00:00 2001
+From: Michal Privoznik <mprivozn@redhat.com>
+Date: Mon, 27 Nov 2023 15:04:43 +0100
+Subject: [PATCH] Make xmlError structs constant
+
+In libxml2 commits v2.12.0~14 and v2.12.0~77 the API changed so
+that:
+
+1) xmlGetLastError() returns pointer to a constant xmlError
+   struct, and
+
+2) xmlSetStructuredErrorFunc() changed the signature of callback
+   (validate_structured_error_nop()), it too is passed pointer to
+   a constant xmlError struct.
+
+But of course, older libxml2 expects different callback
+signature. Therefore, we need to typecast it anyway.
+
+Also, drop obviously incorrect @error annotation in
+validate_structured_error_nop; the variable is used.
+
+Signed-off-by: Michal Privoznik <mprivozn@redhat.com>
+---
+ tools/osinfo-db-validate.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/tools/osinfo-db-validate.c b/tools/osinfo-db-validate.c
+index a721b4d..b1434a6 100644
+--- a/tools/osinfo-db-validate.c
++++ b/tools/osinfo-db-validate.c
+@@ -35,7 +35,7 @@ static void validate_generic_error_nop(void *userData G_GNUC_UNUSED,
+ }
+
+ static void validate_structured_error_nop(void *userData G_GNUC_UNUSED,
+-                                          xmlErrorPtr error G_GNUC_UNUSED)
++                                          const xmlError *error)
+ {
+     if (error->file)
+         g_printerr("%s:%d %s", error->file, error->line, error->message);
+@@ -173,7 +173,8 @@ static gboolean validate_files(GFile *schema, gsize nfiles, GFile **files, GErro
+     g_autofree gchar *schemapath = NULL;
+
+     xmlSetGenericErrorFunc(NULL, validate_generic_error_nop);
+-    xmlSetStructuredErrorFunc(NULL, validate_structured_error_nop);
++    /* Drop this typecast when >=libxml2-2.12.0 is required */
++    xmlSetStructuredErrorFunc(NULL, (xmlStructuredErrorFunc) validate_structured_error_nop);
+
+     schemapath = g_file_get_path(schema);
+     rngParser = xmlRelaxNGNewParserCtxt(schemapath);
+--
+2.34.1
+

--- a/recipes-support/libosinfo/osinfo-db-tools_1.11.0.bb
+++ b/recipes-support/libosinfo/osinfo-db-tools_1.11.0.bb
@@ -1,0 +1,18 @@
+SUMMARY = "Tools for managing the libosinfo database files"
+HOMEPAGE = "https://libosinfo.org"
+
+LICENSE = "GPL-2.0-or-later"
+LIC_FILES_CHKSUM = "file://COPYING;md5=751419260aa954499f7abaabaa882bbe"
+
+DEPENDS = "glib-2.0 json-glib libarchive libsoup-2.4"
+
+SRC_URI = "git://gitlab.com/libosinfo/osinfo-db-tools.git;branch=main;protocol=https \
+           file://0001-Make-xmlError-structs-constant.patch \
+           "
+SRCREV = "85a1788c6977419b6facad11dbfbf823e739eb3b"
+
+S = "${WORKDIR}/git"
+
+inherit meson pkgconfig
+
+BBCLASSEXTEND = "native"

--- a/recipes-support/libosinfo/osinfo-db_20240701.bb
+++ b/recipes-support/libosinfo/osinfo-db_20240701.bb
@@ -1,0 +1,21 @@
+SUMMARY = "osinfo-db provides the database files for use with the libosinfo library"
+HOMEPAGE = "https://libosinfo.org"
+
+LICENSE = "GPL-2.0-or-later"
+LIC_FILES_CHKSUM = "file://COPYING;md5=751419260aa954499f7abaabaa882bbe"
+
+DEPENDS = "osinfo-db-tools-native"
+
+SRC_URI = "git://gitlab.com/libosinfo/osinfo-db.git;branch=main;protocol=https"
+
+SRCREV = "cde78484ab747c87532d47cf3f09b76f280c0b74"
+
+S = "${WORKDIR}/git"
+
+inherit allarch autotools-brokensep
+
+EXTRA_OEMAKE = "OSINFO_DB_TARGET='--dir ${datadir}/osinfo'"
+
+do_configure[noexec] = "1"
+
+FILES:${PN} = "${datadir}/osinfo"


### PR DESCRIPTION
Fix of cockpit-machine issues:

- Some dependencies were missing in virt-manager.
- The libosinfo API used to fetch xml configuration files for cockpit-machine did not work, as introspection data generation was disabled and the osinfo-db database was not installed.
- The libvirt-dbus user and group were not configured, making root access to cockpit-machine impossible. 