### PR TITLE
images/seapath-host-common: install ipmitool for fencing

### DIFF
--- a/recipes-core/images/seapath-host-common-ha.inc
+++ b/recipes-core/images/seapath-host-common-ha.inc
@@ -1,5 +1,5 @@
 # Copyright (C) 2021, RTE (http://www.rte-france.com)
-# Copyright (C) 2023 Savoir-faire Linux, Inc.
+# Copyright (C) 2023-2024 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 # HA
@@ -17,3 +17,6 @@ IMAGE_INSTALL:append = " \
     pacemaker \
     resource-agents \
 "
+
+# Install ipmitool for fencing
+IMAGE_INSTALL:append = " ipmitool"


### PR DESCRIPTION
As it was already done on SEAPATH Debian version, this patch adds ipmitool to the list of packages to install on the host image. This is required for fencing in a pacemaker cluster.