### PR TITLE
Corosync qdevice

### DIFF
--- a/recipes-core/images/seapath-host-common-ha.inc
+++ b/recipes-core/images/seapath-host-common-ha.inc
@@ -16,6 +16,7 @@ IMAGE_INSTALL:append = " \
     net-snmp-configuration-cluster \
     pacemaker \
     resource-agents \
+    corosync-qdevice \
 "
 
 # Install ipmitool for fencing

--- a/recipes-core/images/seapath-monitor-common.inc
+++ b/recipes-core/images/seapath-monitor-common.inc
@@ -12,6 +12,7 @@ IMAGE_INSTALL:append = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'seapath-readonly', 'system-config-ro', '', d)} \
     chrony \
     chronyc \
+    corosync-qnetd \
 "
 
 COMPATIBLE_MACHINE = "seapath-monitor"

--- a/recipes-extended/corosync-qdevice/corosync-qdevice_3.0.3.bb
+++ b/recipes-extended/corosync-qdevice/corosync-qdevice_3.0.3.bb
@@ -1,0 +1,60 @@
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+SUMMARY = "The Corosync Cluster Engine Qdevice"
+DESCRIPTION = "corosync-qdevice is a daemon running on each node of a cluster. \
+It provides a configured number of votes to the quorum subsystem based on a \
+third-party arbitrator's decision. Its primary use is to allow a cluster to \
+sustain more node failures than standard quorum rules allow."
+HOMEPAGE = "https://github.com/corosync/corosync-qdevice"
+BUGTRACKER = "https://github.com/corosync/corosync-qdevice/issues"
+
+CVE_PRODUCT = "corosync-qdevice corosync:corosync-qdevice"
+
+SECTION = "base"
+
+inherit autotools pkgconfig systemd
+
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=269da6ee9fc3cec5265effe22b48e187"
+
+DEPENDS += "corosync nss"
+
+SRC_URI = "https://github.com/corosync/${BPN}/releases/download/v${PV}/${BP}.tar.gz"
+
+SRC_URI[sha256sum] = "0a4705abd17af795287ad3bb18c0abacf3c0027222e45f149cb9bebeb6056926"
+
+SYSTEMD_SERVICE:${PN} = "corosync-qdevice.service"
+SYSTEMD_SERVICE:corosync-qnetd = "corosync-qnetd.service"
+SYSTEMD_AUTO_ENABLE = "disable"
+SYSTEMD_AUTO_ENABLE:corosync-qnetd = "disable"
+
+PACKAGECONFIG ??= "${@bb.utils.filter('DISTRO_FEATURES', 'systemd', d)}"
+
+PACKAGECONFIG[systemd] = "--enable-systemd --with-systemddir=${systemd_system_unitdir},--disable-systemd --without-systemddir,systemd"
+
+EXTRA_OECONF = "ac_cv_path_BASHPATH=${base_bindir}/bash --enable-user-flags"
+
+PACKAGES =+ "corosync-qnetd corosync-qnetd-doc"
+
+do_install:append() {
+    rm -rf ${D}${localstatedir}/run
+}
+
+FILES:corosync-qnetd = "\
+    ${bindir}/corosync-qnetd \
+    ${bindir}/corosync-qnetd-certutil \
+    ${bindir}/corosync-qnetd-tool \
+    ${sysconfdir}/corosync/qnetd \
+    ${sysconfdir}/init.d/corosync-qnetd \
+    ${systemd_system_unitdir}/corosync-qnetd.service \
+"
+
+FILES:corosync-qnetd-doc = "\
+    ${mandir}/man8/corosync-qnetd.8 \
+    ${mandir}/man8/corosync-qnetd-certutil.8 \
+    ${mandir}/man8/corosync-qnetd-tool.8 \
+"
+
+RDEPENDS:${PN} += "bash ${@bb.utils.contains('DISTRO_FEATURES', 'sysvinit', 'sysvinit-pidof', 'procps', d)}"
+RDEPENDS:corosync-qnetd += "bash ${@bb.utils.contains('DISTRO_FEATURES', 'sysvinit', 'sysvinit-pidof', 'procps', d)}"

--- a/recipes-extended/corosync-qdevice/corosync-qdevice_3.0.3.bb
+++ b/recipes-extended/corosync-qdevice/corosync-qdevice_3.0.3.bb
@@ -20,7 +20,10 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=269da6ee9fc3cec5265effe22b48e187"
 
 DEPENDS += "corosync nss"
 
-SRC_URI = "https://github.com/corosync/${BPN}/releases/download/v${PV}/${BP}.tar.gz"
+SRC_URI = "\
+    https://github.com/corosync/${BPN}/releases/download/v${PV}/${BP}.tar.gz \
+    file://0001-init-corosync-qnetd.service-run-as-unprivileged-user.patch \
+"
 
 SRC_URI[sha256sum] = "0a4705abd17af795287ad3bb18c0abacf3c0027222e45f149cb9bebeb6056926"
 
@@ -36,6 +39,17 @@ PACKAGECONFIG[systemd] = "--enable-systemd --with-systemddir=${systemd_system_un
 EXTRA_OECONF = "ac_cv_path_BASHPATH=${base_bindir}/bash --enable-user-flags"
 
 PACKAGES =+ "corosync-qnetd corosync-qnetd-doc"
+
+USERADD_PACKAGES = "corosync-qnetd"
+USERADD_PARAM:corosync-qnetd = " \
+    --system \
+    --no-create-home \
+    --home-dir ${runtimedir}/corosync-qnetd \
+    --shell ${base_sbindir}/nologin \
+    --user-group \
+    --comment 'User for corosync-qnetd' \
+    coroqnetd \
+"
 
 do_install:append() {
     rm -rf ${D}${localstatedir}/run

--- a/recipes-extended/corosync-qdevice/files/0001-init-corosync-qnetd.service-run-as-unprivileged-user.patch
+++ b/recipes-extended/corosync-qdevice/files/0001-init-corosync-qnetd.service-run-as-unprivileged-user.patch
@@ -1,0 +1,32 @@
+From 7bf86a82ddd31c53c9dbb17e0fbb513fdbe3d73a Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Mathieu=20Dupr=C3=A9?= <mathieu.dupre@savoirfairelinux.com>
+Date: Mon, 26 Aug 2024 10:33:31 +0200
+Subject: [PATCH] init/corosync-qnetd.service: run as unprivileged user
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This patch sets the User directive in the corosync-qnetd.service file to
+coroqnetd. This is the user that the qnetd daemon should run as.
+
+Signed-off-by: Mathieu Dupré <mathieu.dupre@savoirfairelinux.com>
+---
+ init/corosync-qnetd.service.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/init/corosync-qnetd.service.in b/init/corosync-qnetd.service.in
+index a8d6a7e..8b59110 100644
+--- a/init/corosync-qnetd.service.in
++++ b/init/corosync-qnetd.service.in
+@@ -12,7 +12,7 @@ Type=notify
+ StandardError=null
+ Restart=on-abnormal
+ # Uncomment and set user who should be used for executing qnetd
+-#User=coroqnetd
++User=coroqnetd
+ RuntimeDirectory=corosync-qnetd
+ RuntimeDirectoryMode=0770
+ 
+-- 
+2.34.1
+


### PR DESCRIPTION
Add corosync-qdevice and corosync-qnetd daemons.

There are used to provide additional votes to the quorum subsystem based on a third-party arbitrator's decision.
They can be used on an even number of nodes to provide a quorum.

These daemons are an alternative to avoid running a full Pacemaker/Corosync stack on the monitor machine.

* corosync-qdevice daemons are run on each corosync nodes.
* corosync-qnetd daemon run in the monitor.