### PR TITLE
conf/machine/seapath-vm: remove console=tty0 from kernel command line

### DIFF
--- a/conf/machine/seapath-vm.conf
+++ b/conf/machine/seapath-vm.conf
@@ -8,3 +8,6 @@
 
 require conf/machine/seapath-machine-common.inc
 MACHINE_FEATURES:append = "seapath-guest"
+
+# We only need the serial console on VM
+APPEND:remove = "console=tty0"


### PR DESCRIPTION
WMs don't need a console=tty0 on the kernel command line, as they don't have a graphical console. This change removes the console=tty0 from the kernel command line for the seapath-vm machine.