### PR TITLE
linuxptp: install /etc/linuxptp directory

### DIFF
--- a/recipes-connectivity/linuxptp/linuxptp_%.bbappend
+++ b/recipes-connectivity/linuxptp/linuxptp_%.bbappend
@@ -19,6 +19,7 @@ do_install:append() {
   install -m 0644 ${WORKDIR}/ptp4l@.service ${D}${systemd_system_unitdir}/
   install -m 0644 ${WORKDIR}/phc2sys@.service ${D}${systemd_system_unitdir}/
   install -m 0644 ${WORKDIR}/timemaster.service ${D}${systemd_system_unitdir}/
+  install -d ${D}/etc/linuxptp
 }
 
 FILES:${PN} += "${systemd_system_unitdir}/ptp4l@.service"


### PR DESCRIPTION
This directory will contain the timemaster configuration. The configuration file itsefl is uploaded by ansible, but the directory should be created by Yocto.