### PR TITLE
seapath-installer: add convenient entries to the grub menu

### DIFF
--- a/conf/machine/seapath-installer.conf
+++ b/conf/machine/seapath-installer.conf
@@ -12,3 +12,22 @@ PREFERRED_VERSION_linux-mainline-rt ?= "6.1.%"
 IMAGE_FSTYPES = "wic"
 SERIAL_CONSOLES = "115200;ttyS0"
 EFI_PROVIDER = "grub-efi"
+GRUB_BUILDIN = "\
+    boot \
+    configfile \
+    efi_gop \
+    efifwsetup \
+    ext2 \
+    fat \
+    iso9660 \
+    linux \
+    loadenv \
+    minicmd \
+    normal \
+    part_gpt \
+    part_msdos \
+    reboot \
+    search \
+    serial \
+    test \
+"

--- a/recipes-core/images/seapath-flasher.bb
+++ b/recipes-core/images/seapath-flasher.bb
@@ -28,5 +28,7 @@ EXTRA_IMAGE_FEATURES = ""
 
 COMPATIBLE_MACHINE = "seapath-installer"
 
-WKS_FILE = "flasher.wks.in"
+PACKAGE_INSTALL += "ovmf-shell-efi"
+IMAGE_EFI_BOOT_FILES = "${KERNEL_IMAGETYPE} microcode.cpio shellx64.efi;efi/boot/shellx64.efi"
 
+WKS_FILE = "flasher.wks.in"

--- a/recipes-core/ovmf/ovmf_%.bbappend
+++ b/recipes-core/ovmf/ovmf_%.bbappend
@@ -1,0 +1,14 @@
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+do_install:append () {
+    if [ -f "${D}/efi/boot/bootx64.efi" ]; then
+        mv "${D}/efi/boot/bootx64.efi" "${D}/efi/boot/shellx64.efi"
+    fi
+}
+
+do_deploy:class-target:append () {
+    if [ "${TARGET_ARCH}" = "x86_64" ]; then
+        cp  "${D}/efi/boot/shellx64.efi" "${DEPLOYDIR}/shellx64.efi"
+    fi
+}

--- a/wic/flasher-grub-config.cfg
+++ b/wic/flasher-grub-config.cfg
@@ -1,0 +1,26 @@
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+serial --unit=0 --speed=115200 --word=8 --parity=no --stop=1
+default=seapath-flash
+timeout=5
+menuentry 'seapath-flash'{
+    linux /bzImage LABEL=seapath-flash rootwait quiet ro efi=runtime rootwait console=ttyS0,115200 console=tty0
+    initrd /microcode.cpio /seapath-flasher-cpio-seapath-installer.cpio.gz
+}
+
+menuentry 'UEFI Shell' {
+    chainloader /efi/boot/shellx64.efi
+}
+
+menuentry 'Firmware setup' {
+    fwsetup
+}
+
+menuentry 'Reboot' {
+    reboot
+}
+
+menuentry 'Normal Boot' {
+    exit
+}

--- a/wic/flasher.wks.in
+++ b/wic/flasher.wks.in
@@ -1,13 +1,13 @@
 # Copyright (C) 2020, RTE (http://www.rte-france.com)
-# Copyright (C) 2023 Savoir-faire Linux, Inc.
+# Copyright (C) 2023-2024 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 
 # short-description: Create a flasher image
 # long-description: Creates a partitioned disk image that the user
 # can directly dd to boot media.
-part /boot --source bootimg-biosplusefi --sourceparams="loader=${EFI_PROVIDER},title=seapath-flash,label=seapath-flash,initrd=microcode.cpio;${IMAGE_BASENAME}-cpio-${MACHINE}.${INITRAMFS_FSTYPES}" --ondisk sda --label flasher --active --align 1024 --use-uuid --fsoptions="defaults,ro"
+part /boot --source bootimg-efi --sourceparams="loader=${EFI_PROVIDER},title=seapath-flash,label=seapath-flash,initrd=microcode.cpio;${IMAGE_BASENAME}-cpio-${MACHINE}.${INITRAMFS_FSTYPES}" --ondisk sda --label flasher --active --align 1024 --use-uuid --fsoptions="defaults,ro"
 
 part /media --ondisk sda --fstype=ext4 --label flasher_data --align 1024 --use-uuid --size 7G --fsoptions="defaults,ro"
 
-bootloader --timeout=5 --append="quiet ro efi=runtime"
+bootloader --configfile="flasher-grub-config.cfg"


### PR DESCRIPTION
This patch adds the following entries to the grub menu:
* UEFI Shell: allows the user to access an UEFI shell
* Firmware setup: allows the user to access the firmware setup
* Reboot: allows the user to reboot the system
* Normal Boot: allows the user to continue the boot process (next UEFI boot entry)