### PR TITLE
images/seapath-host-common-virtu: add libxml2-utils

### DIFF
--- a/recipes-core/images/seapath-host-common-virtu.inc
+++ b/recipes-core/images/seapath-host-common-virtu.inc
@@ -1,4 +1,5 @@
 # Copyright (C) 2021, RTE (http://www.rte-france.com)
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 # Virtualization
@@ -11,4 +12,5 @@ IMAGE_INSTALL:append = " \
     net-snmp-configuration-virtualization \
     openvswitch \
     qemu \
+    libxml2-utils \
 "


### PR DESCRIPTION
This package contains xmllint, a command line XML tool. It is used to validate the xml file and print the error if the file is not valid.

xmllinit is used by libvirt to add more information if the xml file is not valid. It is also used by the resource-agents VirtualDomain during the configuration saving.