### PR TITLE
cluster-resource-agents: add support of sync_config_on_stop

### DIFF
--- a/recipes-cgl/cluster-resource-agents/files/VirtualDomain
+++ b/recipes-cgl/cluster-resource-agents/files/VirtualDomain
@@ -819,7 +819,15 @@ save_config(){
 			if virt-xml-validate ${CFGTMP} domain 2>/dev/null ;	then
 				ocf_log info "Saving domain $DOMAIN_NAME to ${OCF_RESKEY_config}. Please make sure it's present on all nodes or sync_config_on_stop is on."
 				if cat ${CFGTMP} > ${OCF_RESKEY_config} ; then
-					ocf_log info "Saved $DOMAIN_NAME domain's configuration to ${OCF_RESKEY_config}."
+					if ocf_is_true "$OCF_RESKEY_seapath" ; then
+						if rbd image-meta set system_${DOMAIN_NAME} xml < ${CFGTMP} ; then
+							ocf_log info "Saved $DOMAIN_NAME domain's configuration to ${OCF_RESKEY_config} and rbd system_${DOMAIN_NAME} metadata"
+						else
+							ocf_log warn "Saving $DOMAIN_NAME domain's configuration to rbd system_${DOMAIN_NAME} metadata failed."
+						fi
+					else
+						ocf_log info "Saved $DOMAIN_NAME domain's configuration to ${OCF_RESKEY_config}."
+					fi
 					if ocf_is_true "$OCF_RESKEY_sync_config_on_stop"; then
 						sync_config
 					fi


### PR DESCRIPTION
This patch adds the support of the "sync_config_on_stop parameter" when "seapath" parameter is set to "true" in VirtualDomain resource agent.

When the "sync_config_on_stop" parameter is set to "true", the domain configuration is saved to the rbd image metadata when the resource is stopped.