### PR TITLE
ovmf: fix task dependency for do_deploy

### DIFF
--- a/recipes-core/ovmf/ovmf_%.bbappend
+++ b/recipes-core/ovmf/ovmf_%.bbappend
@@ -12,3 +12,5 @@ do_deploy:class-target:append () {
         cp  "${D}/efi/boot/shellx64.efi" "${DEPLOYDIR}/shellx64.efi"
     fi
 }
+
+addtask do_deploy after do_install before do_build


### PR DESCRIPTION
The base ovmf recipe in poky only specify that do_deploy must run after do_compile. However, commit [1] use deploy file shellx64.efi that is available after do_install.

Fix task order so do_deploy runs after do_install.

[1]: https://github.com/seapath/meta-seapath/commit/ab718ab67520e08cbf38636088226a574cb6b073

Change-Id: I62baf177ae7d8a75dc1020b0a15c51119b296350