### PR TITLE
cluster-resource-agents/VirtualDomain: save_config fix

### DIFF
--- a/recipes-cgl/cluster-resource-agents/files/VirtualDomain
+++ b/recipes-cgl/cluster-resource-agents/files/VirtualDomain
@@ -820,7 +820,7 @@ save_config(){
 				ocf_log info "Saving domain $DOMAIN_NAME to ${OCF_RESKEY_config}. Please make sure it's present on all nodes or sync_config_on_stop is on."
 				if cat ${CFGTMP} > ${OCF_RESKEY_config} ; then
 					if ocf_is_true "$OCF_RESKEY_seapath" ; then
-						if rbd image-meta set system_${DOMAIN_NAME} xml < ${CFGTMP} ; then
+						if rbd image-meta set system_${DOMAIN_NAME} xml "$(cat ${CFGTMP})" ; then
 							ocf_log info "Saved $DOMAIN_NAME domain's configuration to ${OCF_RESKEY_config} and rbd system_${DOMAIN_NAME} metadata"
 						else
 							ocf_log warn "Saving $DOMAIN_NAME domain's configuration to rbd system_${DOMAIN_NAME} metadata failed."


### PR DESCRIPTION
The save_config function in the VirtualDomain RA was not saving the configuration to the rbd image metadata. The rbd command was not properly called to set the metadata.