### PR TITLE
recipes-connectivity/netplan: fix infinite timeouts in ovs-vsctl

### DIFF
--- a/recipes-connectivity/netplan/netplan/0001-fix-infinite-timeouts-in-ovs-vsctl.patch
+++ b/recipes-connectivity/netplan/netplan/0001-fix-infinite-timeouts-in-ovs-vsctl.patch
@@ -1,0 +1,604 @@
+From 51a8e93fd4fe5c708462882a998969fa7305cb2c Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Lukas=20M=C3=A4rdian?= <slyon@ubuntu.com>
+Date: Wed, 11 May 2022 18:11:20 +0200
+Subject: [PATCH] Fix infinite timeouts in ovs-vsctl (Closes: #1000137) (#266)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+* ovs: time out OVS commands after a while
+
+* tests: time out ovs-vsctl commands
+
+ovs-vsctl will hang forever if the host is not OVS enabled, blocking the tests
+
+Upstream-Status: Backport [https://github.com/canonical/netplan/commit/62f0a75e8e69149578bef1007cc808810b3440d3]
+Signed-off-by: Mathieu Dupré <mathieu.dupre@savoirfairelinux.com>
+---
+ src/openvswitch.c           |   2 +-
+ tests/generator/base.py     |   4 +-
+ tests/generator/test_ovs.py |  29 +++++++++
+ tests/integration/ovs.py    | 117 ++++++++++++++++++------------------
+ 4 files changed, 91 insertions(+), 61 deletions(-)
+
+diff --git a/src/openvswitch.c b/src/openvswitch.c
+index 7479267..b625588 100644
+--- a/src/openvswitch.c
++++ b/src/openvswitch.c
+@@ -59,7 +59,7 @@ write_ovs_systemd_unit(const char* id, const GString* cmds, const char* rootdir,
+         g_string_append_printf(s, "After=netplan-ovs-%s.service\n", dependency);
+     }
+ 
+-    g_string_append(s, "\n[Service]\nType=oneshot\n");
++    g_string_append(s, "\n[Service]\nType=oneshot\nTimeoutStartSec=10s\n");
+     g_string_append(s, cmds->str);
+ 
+     g_string_free_to_file(s, rootdir, path, NULL);
+diff --git a/tests/generator/base.py b/tests/generator/base.py
+index d9396dd..da17167 100644
+--- a/tests/generator/base.py
++++ b/tests/generator/base.py
+@@ -66,9 +66,9 @@ standalone\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s mcast_snooping_ena
+ Bridge %(iface)s external-ids:netplan/mcast_snooping_enable=false\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s \
+ rstp_enable=false\nExecStart=/usr/bin/ovs-vsctl set Bridge %(iface)s external-ids:netplan/rstp_enable=false\n'
+ OVS_BR_EMPTY = _OVS_BASE + 'After=netplan-ovs-cleanup.service\nBefore=network.target\nWants=network.target\n\n[Service]\n\
+-Type=oneshot\nExecStart=/usr/bin/ovs-vsctl --may-exist add-br %(iface)s\n' + OVS_BR_DEFAULT
++Type=oneshot\nTimeoutStartSec=10s\nExecStart=/usr/bin/ovs-vsctl --may-exist add-br %(iface)s\n' + OVS_BR_DEFAULT
+ OVS_CLEANUP = _OVS_BASE + 'ConditionFileIsExecutable=/usr/bin/ovs-vsctl\nBefore=network.target\nWants=network.target\n\n\
+-[Service]\nType=oneshot\nExecStart=/usr/sbin/netplan apply --only-ovs-cleanup\n'
++[Service]\nType=oneshot\nTimeoutStartSec=10s\nExecStart=/usr/sbin/netplan apply --only-ovs-cleanup\n'
+ UDEV_MAC_RULE = 'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="%s", ATTR{address}=="%s", NAME="%s"\n'
+ UDEV_NO_MAC_RULE = 'SUBSYSTEM=="net", ACTION=="add", DRIVERS=="%s", NAME="%s"\n'
+ UDEV_SRIOV_RULE = 'ACTION=="add", SUBSYSTEM=="net", ATTRS{sriov_totalvfs}=="?*", RUN+="/usr/sbin/netplan apply --sriov-only"\n'
+diff --git a/tests/generator/test_ovs.py b/tests/generator/test_ovs.py
+index dff2989..e09973f 100644
+--- a/tests/generator/test_ovs.py
++++ b/tests/generator/test_ovs.py
+@@ -50,6 +50,7 @@ class TestOpenVSwitch(TestBase):
+         self.assert_ovs({'ovs0.service': OVS_VIRTUAL % {'iface': 'ovs0', 'extra': '''
+ [Service]
+ Type=oneshot
++TimeoutStartSec=10s
+ ExecStart=/usr/bin/ovs-vsctl --may-exist add-br ovs0
+ ExecStart=/usr/bin/ovs-vsctl --may-exist add-port ovs0 eth1
+ ExecStart=/usr/bin/ovs-vsctl --may-exist add-port ovs0 eth0
+@@ -60,6 +61,7 @@ After=netplan-ovs-ovs0.service
+ 
+ [Service]
+ Type=oneshot
++TimeoutStartSec=10s
+ ExecStart=/usr/bin/ovs-vsctl set Interface eth0 external-ids:iface-id=myhostname
+ ExecStart=/usr/bin/ovs-vsctl set Interface eth0 external-ids:netplan/external-ids/iface-id=myhostname
+ ExecStart=/usr/bin/ovs-vsctl set Interface eth0 other-config:disable-in-band=true
+@@ -71,6 +73,7 @@ After=netplan-ovs-ovs0.service
+ 
+ [Service]
+ Type=oneshot
++TimeoutStartSec=10s
+ ExecStart=/usr/bin/ovs-vsctl set Interface eth1 other-config:disable-in-band=false
+ ExecStart=/usr/bin/ovs-vsctl set Interface eth1 external-ids:netplan/other-config/disable-in-band=false
+ '''},
+@@ -109,6 +112,7 @@ ExecStart=/usr/bin/ovs-vsctl set Interface eth1 external-ids:netplan/other-confi
+         self.assert_ovs({'global.service': OVS_VIRTUAL % {'iface': 'global', 'extra': '''
+ [Service]
+ Type=oneshot
++TimeoutStartSec=10s
+ ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:iface-id=myhostname
+ ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/external-ids/iface-id=myhostname
+ ExecStart=/usr/bin/ovs-vsctl set open_vswitch . other-config:disable-in-band=true
+@@ -129,6 +133,7 @@ ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/other-confi
+         self.assert_ovs({'ovs0.service': OVS_VIRTUAL % {'iface': 'ovs0', 'extra': '''
+ [Service]
+ Type=oneshot
++TimeoutStartSec=10s
+ ExecStart=/usr/bin/ovs-vsctl --may-exist add-br ovs0
+ ''' + OVS_BR_DEFAULT % {'iface': 'ovs0'} + '''\
+ ExecStart=/usr/bin/ovs-vsctl set Bridge ovs0 protocols=OpenFlow10,OpenFlow11,OpenFlow12
+@@ -185,6 +190,7 @@ After=netplan-ovs-br0.service
+ 
+ [Service]
+ Type=oneshot
++TimeoutStartSec=10s
+ ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
+ ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
+ ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
+@@ -253,6 +259,7 @@ After=netplan-ovs-br0.service
+ 
+ [Service]
+ Type=oneshot
++TimeoutStartSec=10s
+ ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
+ ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
+ ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=active
+@@ -318,6 +325,7 @@ After=netplan-ovs-br0.service
+ 
+ [Service]
+ Type=oneshot
++TimeoutStartSec=10s
+ ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
+ ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
+ ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
+@@ -357,6 +365,7 @@ After=netplan-ovs-br0.service
+ 
+ [Service]
+ Type=oneshot
++TimeoutStartSec=10s
+ ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
+ ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
+ ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
+@@ -408,6 +417,7 @@ ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan/bond_mode=activ
+                         '''
+ [Service]
+ Type=oneshot
++TimeoutStartSec=10s
+ ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
+ ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br0 eth1
+ ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br0 eth2
+@@ -432,6 +442,7 @@ ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br0 eth2
+         self.assert_ovs({'br0.service': OVS_VIRTUAL % {'iface': 'br0', 'extra': '''
+ [Service]
+ Type=oneshot
++TimeoutStartSec=10s
+ ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
+ ''' + OVS_BR_DEFAULT % {'iface': 'br0'} + '''\
+ ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:iface-id=myhostname
+@@ -462,6 +473,7 @@ ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan/other-config/di
+                         '''
+ [Service]
+ Type=oneshot
++TimeoutStartSec=10s
+ ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
+ ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br0 eth1
+ ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br0 eth2
+@@ -521,6 +533,7 @@ ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan/rstp_enable=tru
+                         '''
+ [Service]
+ Type=oneshot
++TimeoutStartSec=10s
+ ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
+ ''' + OVS_BR_DEFAULT % {'iface': 'br0'} + '''\
+ ExecStart=/usr/bin/ovs-vsctl set Bridge br0 protocols=OpenFlow10,OpenFlow11,OpenFlow15
+@@ -570,6 +583,7 @@ ExecStart=/usr/bin/ovs-vsctl set Bridge br0 external-ids:netplan/protocols=OpenF
+                         '''
+ [Service]
+ Type=oneshot
++TimeoutStartSec=10s
+ ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
+ ''' + OVS_BR_DEFAULT % {'iface': 'br0'} + '''\
+ ExecStart=/usr/bin/ovs-vsctl set-controller br0 ptcp: ptcp:1337 ptcp:1337:[fe80::1234%eth0] pssl:1337:[fe80::1] ssl:10.10.10.1 \
+@@ -583,6 +597,7 @@ ExecStart=/usr/bin/ovs-vsctl set Controller br0 external-ids:netplan/connection-
+                          'global.service': OVS_VIRTUAL % {'iface': 'global', 'extra': '''
+ [Service]
+ Type=oneshot
++TimeoutStartSec=10s
+ ExecStart=/usr/bin/ovs-vsctl set-ssl /key/path /some/path /another/path
+ ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/global/set-ssl=/key/path,/some/path,/another/path
+ '''},
+@@ -680,6 +695,7 @@ ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/global/set-
+         self.assert_ovs({'global.service': OVS_VIRTUAL % {'iface': 'global', 'extra': '''
+ [Service]
+ Type=oneshot
++TimeoutStartSec=10s
+ ExecStart=/usr/bin/ovs-vsctl set-ssl /key/path /some/path /another/path
+ ExecStart=/usr/bin/ovs-vsctl set open_vswitch . external-ids:netplan/global/set-ssl=/key/path,/some/path,/another/path
+ '''},
+@@ -784,6 +800,7 @@ After=netplan-ovs-br0.service
+ 
+ [Service]
+ Type=oneshot
++TimeoutStartSec=10s
+ ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 eth1 eth2
+ ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
+ ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
+@@ -832,6 +849,7 @@ Bond=bond0
+                          'br1.service': OVS_VIRTUAL % {'iface': 'br1', 'extra': '''
+ [Service]
+ Type=oneshot
++TimeoutStartSec=10s
+ ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br1
+ ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br1 patchx -- set Interface patchx type=patch options:peer=patchy
+ ''' + OVS_BR_DEFAULT % {'iface': 'br1'}},
+@@ -841,6 +859,7 @@ After=netplan-ovs-br0.service
+ 
+ [Service]
+ Type=oneshot
++TimeoutStartSec=10s
+ ExecStart=/usr/bin/ovs-vsctl --may-exist add-bond br0 bond0 patchy eth0 -- set Interface patchy type=patch options:peer=patchx
+ ExecStart=/usr/bin/ovs-vsctl set Port bond0 external-ids:netplan=true
+ ExecStart=/usr/bin/ovs-vsctl set Port bond0 lacp=off
+@@ -852,6 +871,7 @@ After=netplan-ovs-br1.service
+ 
+ [Service]
+ Type=oneshot
++TimeoutStartSec=10s
+ ExecStart=/usr/bin/ovs-vsctl set Port patchx external-ids:netplan=true
+ '''},
+                          'patchy.service': OVS_VIRTUAL % {'iface': 'patchy', 'extra':
+@@ -860,6 +880,7 @@ After=netplan-ovs-bond0.service
+ 
+ [Service]
+ Type=oneshot
++TimeoutStartSec=10s
+ ExecStart=/usr/bin/ovs-vsctl set Interface patchy external-ids:netplan=true
+ '''},
+                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
+@@ -887,12 +908,14 @@ ExecStart=/usr/bin/ovs-vsctl set Interface patchy external-ids:netplan=true
+         self.assert_ovs({'br0.service': OVS_VIRTUAL % {'iface': 'br0', 'extra': '''
+ [Service]
+ Type=oneshot
++TimeoutStartSec=10s
+ ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
+ ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br0 patch0-1 -- set Interface patch0-1 type=patch options:peer=patch1-0
+ ''' + OVS_BR_DEFAULT % {'iface': 'br0'}},
+                          'br1.service': OVS_VIRTUAL % {'iface': 'br1', 'extra': '''
+ [Service]
+ Type=oneshot
++TimeoutStartSec=10s
+ ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br1
+ ExecStart=/usr/bin/ovs-vsctl --may-exist add-port br1 patch1-0 -- set Interface patch1-0 type=patch options:peer=patch0-1
+ ''' + OVS_BR_DEFAULT % {'iface': 'br1'}},
+@@ -902,6 +925,7 @@ After=netplan-ovs-br0.service
+ 
+ [Service]
+ Type=oneshot
++TimeoutStartSec=10s
+ ExecStart=/usr/bin/ovs-vsctl set Port patch0-1 external-ids:netplan=true
+ '''},
+                          'patch1-0.service': OVS_VIRTUAL % {'iface': 'patch1-0', 'extra':
+@@ -910,6 +934,7 @@ After=netplan-ovs-br1.service
+ 
+ [Service]
+ Type=oneshot
++TimeoutStartSec=10s
+ ExecStart=/usr/bin/ovs-vsctl set Port patch1-0 external-ids:netplan=true
+ '''},
+                          'cleanup.service': OVS_CLEANUP % {'iface': 'cleanup'}})
+@@ -934,6 +959,7 @@ ExecStart=/usr/bin/ovs-vsctl set Port patch1-0 external-ids:netplan=true
+         self.assert_ovs({'br0.service': OVS_VIRTUAL % {'iface': 'br0', 'extra': '''
+ [Service]
+ Type=oneshot
++TimeoutStartSec=10s
+ ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0
+ ''' + OVS_BR_DEFAULT % {'iface': 'br0'}},
+                          'br0.100.service': OVS_VIRTUAL % {'iface': 'br0.100', 'extra':
+@@ -942,6 +968,7 @@ After=netplan-ovs-br0.service
+ 
+ [Service]
+ Type=oneshot
++TimeoutStartSec=10s
+ ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0.100 br0 100
+ ExecStart=/usr/bin/ovs-vsctl set Interface br0.100 external-ids:netplan=true
+ '''},
+@@ -971,6 +998,7 @@ After=netplan-ovs-br0.service
+ 
+ [Service]
+ Type=oneshot
++TimeoutStartSec=10s
+ ExecStart=/usr/bin/ovs-vsctl --may-exist add-br br0.100 br0 100
+ ExecStart=/usr/bin/ovs-vsctl set Interface br0.100 external-ids:netplan=true
+ '''},
+@@ -1007,6 +1035,7 @@ ExecStart=/usr/bin/ovs-vsctl set Interface br0.100 external-ids:netplan=true
+         self.assert_ovs({'ovs-br.service': OVS_VIRTUAL % {'iface': 'ovs-br', 'extra': '''
+ [Service]
+ Type=oneshot
++TimeoutStartSec=10s
+ ExecStart=/usr/bin/ovs-vsctl --may-exist add-br ovs-br
+ ExecStart=/usr/bin/ovs-vsctl --may-exist add-port ovs-br non-ovs-bond
+ ''' + OVS_BR_DEFAULT % {'iface': 'ovs-br'}},
+diff --git a/tests/integration/ovs.py b/tests/integration/ovs.py
+index bfd6eb9..a7f75ef 100644
+--- a/tests/integration/ovs.py
++++ b/tests/integration/ovs.py
+@@ -31,8 +31,8 @@ class _CommonTests():
+ 
+     def _collect_ovs_settings(self, bridge0):
+         d = {}
+-        d['show'] = subprocess.check_output(['ovs-vsctl', 'show'])
+-        d['ssl'] = subprocess.check_output(['ovs-vsctl', 'get-ssl'])
++        d['show'] = subprocess.check_output(['ovs-vsctl', '-t', '5', 'show'])
++        d['ssl'] = subprocess.check_output(['ovs-vsctl', '-t', '5', 'get-ssl'])
+         # Get external-ids
+         for tbl in ('Open_vSwitch', 'Controller', 'Bridge', 'Port', 'Interface'):
+             cols = 'name,external-ids'
+@@ -40,37 +40,37 @@ class _CommonTests():
+                 cols = 'external-ids'
+             elif tbl == 'Controller':
+                 cols = '_uuid,external-ids'
+-            d['external-ids-%s' % tbl] = subprocess.check_output(['ovs-vsctl', '--columns=%s' % cols, '-f', 'csv', '-d',
+-                                                                  'bare', '--no-headings', 'list', tbl])
++            d['external-ids-%s' % tbl] = subprocess.check_output(['ovs-vsctl', '-t', '5', '--columns=%s' % cols, '-f', 'csv',
++                                                                  '-d', 'bare', '--no-headings', 'list', tbl])
+         # Get other-config
+         for tbl in ('Open_vSwitch', 'Bridge', 'Port', 'Interface'):
+             cols = 'name,other-config'
+             if tbl == 'Open_vSwitch':
+                 cols = 'other-config'
+-            d['other-config-%s' % tbl] = subprocess.check_output(['ovs-vsctl', '--columns=%s' % cols, '-f', 'csv', '-d',
+-                                                                  'bare', '--no-headings',  'list', tbl])
++            d['other-config-%s' % tbl] = subprocess.check_output(['ovs-vsctl', '-t', '5', '--columns=%s' % cols, '-f', 'csv',
++                                                                  '-d', 'bare', '--no-headings',  'list', tbl])
+         # Get bond settings
+         for col in ('bond_mode', 'lacp'):
+-            d['%s-Bond' % col] = subprocess.check_output(['ovs-vsctl', '--columns=name,%s' % col, '-f', 'csv', '-d', 'bare',
+-                                                           '--no-headings', 'list', 'Port'])
++            d['%s-Bond' % col] = subprocess.check_output(['ovs-vsctl', '-t', '5', '--columns=name,%s' % col, '-f', 'csv',
++                                                          '-d', 'bare', '--no-headings', 'list', 'Port'])
+         # Get bridge settings
+-        d['set-fail-mode-Bridge'] = subprocess.check_output(['ovs-vsctl', 'get-fail-mode', bridge0])
++        d['set-fail-mode-Bridge'] = subprocess.check_output(['ovs-vsctl', '-t', '5', 'get-fail-mode', bridge0])
+         for col in ('mcast_snooping_enable', 'rstp_enable', 'protocols'):
+-            d['%s-Bridge' % col] = subprocess.check_output(['ovs-vsctl', '--columns=name,%s' % col, '-f', 'csv', '-d', 'bare',
+-                                                             '--no-headings', 'list', 'Bridge'])
++            d['%s-Bridge' % col] = subprocess.check_output(['ovs-vsctl', '-t', '5', '--columns=name,%s' % col, '-f', 'csv',
++                                                            '-d', 'bare', '--no-headings', 'list', 'Bridge'])
+         # Get controller settings
+-        d['set-controller-Bridge'] = subprocess.check_output(['ovs-vsctl', 'get-controller', bridge0])
++        d['set-controller-Bridge'] = subprocess.check_output(['ovs-vsctl', '-t', '5', 'get-controller', bridge0])
+         for col in ('connection_mode',):
+-            d['%s-Controller' % col] = subprocess.check_output(['ovs-vsctl', '--columns=_uuid,%s' % col, '-f', 'csv', '-d',
+-                                                                'bare', '--no-headings', 'list', 'Controller'])
++            d['%s-Controller' % col] = subprocess.check_output(['ovs-vsctl', '-t', '5', '--columns=_uuid,%s' % col, '-f', 'csv',
++                                                                '-d', 'bare', '--no-headings', 'list', 'Controller'])
+         return d
+ 
+     def test_cleanup_interfaces(self):
+         self.setup_eth(None, False)
+-        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'ovs0'])
+-        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'ovs1'])
+-        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-port', 'patch0-1'])
+-        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-port', 'patch1-0'])
++        self.addCleanup(subprocess.call, ['ovs-vsctl', '-t', '5', '--if-exists', 'del-br', 'ovs0'])
++        self.addCleanup(subprocess.call, ['ovs-vsctl', '-t', '5', '--if-exists', 'del-br', 'ovs1'])
++        self.addCleanup(subprocess.call, ['ovs-vsctl', '-t', '5', '--if-exists', 'del-port', 'patch0-1'])
++        self.addCleanup(subprocess.call, ['ovs-vsctl', '-t', '5', '--if-exists', 'del-port', 'patch1-0'])
+         with open(self.config, 'w') as f:
+             f.write('''network:
+   openvswitch:
+@@ -81,7 +81,7 @@ class _CommonTests():
+     ovs1: {interfaces: [patch1-0]}''')
+         self.generate_and_settle(['ovs0', 'ovs1'])
+         # Basic verification that the bridges/ports/interfaces are there in OVS
+-        out = subprocess.check_output(['ovs-vsctl', 'show'])
++        out = subprocess.check_output(['ovs-vsctl', '-t', '5', 'show'])
+         self.assertIn(b'    Bridge ovs0', out)
+         self.assertIn(b'        Port patch0-1', out)
+         self.assertIn(b'            Interface patch0-1', out)
+@@ -94,7 +94,7 @@ class _CommonTests():
+     %(ec)s: {addresses: ['1.2.3.4/24']}''' % {'ec': self.dev_e_client})
+         self.generate_and_settle([self.dev_e_client])
+         # Verify that the netplan=true tagged bridges/ports have been cleaned up
+-        out = subprocess.check_output(['ovs-vsctl', 'show'])
++        out = subprocess.check_output(['ovs-vsctl', '-t', '5', 'show'])
+         self.assertNotIn(b'Bridge ovs0', out)
+         self.assertNotIn(b'Port patch0-1', out)
+         self.assertNotIn(b'Interface patch0-1', out)
+@@ -105,11 +105,11 @@ class _CommonTests():
+ 
+     def test_cleanup_patch_ports(self):
+         self.setup_eth(None, False)
+-        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'ovs0'])
+-        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'ovs1'])
+-        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-port', 'patch0-1'])
+-        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-port', 'patchy'])
+-        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-port', 'bond0'])
++        self.addCleanup(subprocess.call, ['ovs-vsctl', '-t', '5', '--if-exists', 'del-br', 'ovs0'])
++        self.addCleanup(subprocess.call, ['ovs-vsctl', '-t', '5', '--if-exists', 'del-br', 'ovs1'])
++        self.addCleanup(subprocess.call, ['ovs-vsctl', '-t', '5', '--if-exists', 'del-port', 'patch0-1'])
++        self.addCleanup(subprocess.call, ['ovs-vsctl', '-t', '5', '--if-exists', 'del-port', 'patchy'])
++        self.addCleanup(subprocess.call, ['ovs-vsctl', '-t', '5', '--if-exists', 'del-port', 'bond0'])
+         with open(self.config, 'w') as f:
+             f.write('''network:
+   ethernets:
+@@ -122,7 +122,7 @@ class _CommonTests():
+     ovs0: {interfaces: [patch0-1, bond0]}''' % {'ec': self.dev_e_client})
+         self.generate_and_settle([self.dev_e_client, 'ovs0'])
+         # Basic verification that the bridges/ports/interfaces are there in OVS
+-        out = subprocess.check_output(['ovs-vsctl', 'show'])
++        out = subprocess.check_output(['ovs-vsctl', '-t', '5', 'show'])
+         self.assertIn(b'    Bridge ovs0', out)
+         self.assertIn(b'        Port patch0-1\n            Interface patch0-1\n                type: patch', out)
+         self.assertIn(b'        Port bond0', out)
+@@ -141,7 +141,7 @@ class _CommonTests():
+         self.generate_and_settle([self.dev_e_client, 'ovs1'])
+         # Verify that the netplan=true tagged patch ports have been cleaned up
+         # even though the containing bond0 port still exists (with new patch ports)
+-        out = subprocess.check_output(['ovs-vsctl', 'show'])
++        out = subprocess.check_output(['ovs-vsctl', '-t', '5', 'show'])
+         self.assertIn(b'    Bridge ovs1', out)
+         self.assertIn(b'        Port patchy\n            Interface patchy\n                type: patch', out)
+         self.assertIn(b'        Port bond0', out)
+@@ -155,9 +155,9 @@ class _CommonTests():
+ 
+     def test_bridge_vlan(self):
+         self.setup_eth(None, True)
+-        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'br-%s' % self.dev_e_client])
+-        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'br-data'])
+-        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'br-%s.100' % self.dev_e_client])
++        self.addCleanup(subprocess.call, ['ovs-vsctl', '-t', '5', '--if-exists', 'del-br', 'br-%s' % self.dev_e_client])
++        self.addCleanup(subprocess.call, ['ovs-vsctl', '-t', '5', '--if-exists', 'del-br', 'br-data'])
++        self.addCleanup(subprocess.call, ['ovs-vsctl', '-t', '5', '--if-exists', 'del-br', 'br-%s.100' % self.dev_e_client])
+         with open(self.config, 'w') as f:
+             f.write('''network:
+     version: 2
+@@ -183,7 +183,7 @@ class _CommonTests():
+                                   'br-data',
+                                   'br-eth42.100'])
+         # Basic verification that the interfaces/ports are set up in OVS
+-        out = subprocess.check_output(['ovs-vsctl', 'show'])
++        out = subprocess.check_output(['ovs-vsctl', '-t', '5', 'show'])
+         self.assertIn(b'    Bridge br-%b' % self.dev_e_client.encode(), out)
+         self.assertIn(b'''        Port %(ec)b
+             Interface %(ec)b''' % {b'ec': self.dev_e_client.encode()}, out)
+@@ -196,16 +196,16 @@ class _CommonTests():
+                           ['inet 192.168.5.[0-9]+/16', 'mtu 9000'])  # from DHCP
+         self.assert_iface('br-data', ['inet 192.168.20.1/16'])
+         self.assert_iface(self.dev_e_client, ['mtu 9000', 'master ovs-system'])
+-        self.assertIn(b'100', subprocess.check_output(['ovs-vsctl', 'br-to-vlan',
++        self.assertIn(b'100', subprocess.check_output(['ovs-vsctl', '-t', '5', 'br-to-vlan',
+                       'br-%s.100' % self.dev_e_client]))
+         self.assertIn(b'br-%b' % self.dev_e_client.encode(), subprocess.check_output(
+-                      ['ovs-vsctl', 'br-to-parent', 'br-%s.100' % self.dev_e_client]))
++                      ['ovs-vsctl', '-t', '5', 'br-to-parent', 'br-%s.100' % self.dev_e_client]))
+         self.assertIn(b'br-%b' % self.dev_e_client.encode(), out)
+ 
+     def test_bridge_vlan_deletion(self):
+         self.setup_eth(None, True)
+-        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'br-%s' % self.dev_e_client])
+-        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'br-%s.100' % self.dev_e_client])
++        self.addCleanup(subprocess.call, ['ovs-vsctl', '-t', '5', '--if-exists', 'del-br', 'br-%s' % self.dev_e_client])
++        self.addCleanup(subprocess.call, ['ovs-vsctl', '-t', '5', '--if-exists', 'del-br', 'br-%s.100' % self.dev_e_client])
+         with open(self.config, 'w') as f:
+             f.write('''network:
+     version: 2
+@@ -228,13 +228,13 @@ class _CommonTests():
+                                   'br-eth42.100'])
+ 
+         # Basic verification that the underlying bridge and vlan interface are configured
+-        out = subprocess.check_output(['ovs-vsctl', 'show'])
++        out = subprocess.check_output(['ovs-vsctl', '-t', '5', 'show'])
+         self.assertIn(b'    Bridge br-%b' % self.dev_e_client.encode(), out)
+         self.assertIn(b'''        Port br-%(ec)b.100
+             tag: 100
+             Interface br-%(ec)b.100
+                 type: internal''' % {b'ec': self.dev_e_client.encode()}, out)
+-        self.assertIn(b'100', subprocess.check_output(['ovs-vsctl', 'br-to-vlan',
++        self.assertIn(b'100', subprocess.check_output(['ovs-vsctl', '-t', '5', 'br-to-vlan',
+                       'br-%s.100' % self.dev_e_client]))
+ 
+         # Write a network configuration that has the .100 vlan interface removed
+@@ -253,14 +253,14 @@ class _CommonTests():
+         self.generate_and_settle([self.dev_e_client, self.state_dhcp4('br-eth42')])
+ 
+         # Check that the underlying bridge is still present but the vlan interface is now absent
+-        out = subprocess.check_output(['ovs-vsctl', 'show'])
++        out = subprocess.check_output(['ovs-vsctl', '-t', '5', 'show'])
+         self.assertIn(b'    Bridge br-%b' % self.dev_e_client.encode(), out)
+         self.assertNotIn(b'Port br-%(ec)b.100' % {b'ec': self.dev_e_client.encode()}, out)
+ 
+     def test_bridge_base(self):
+         self.setup_eth(None, False)
+-        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'ovsbr'])
+-        self.addCleanup(subprocess.call, ['ovs-vsctl', 'del-ssl'])
++        self.addCleanup(subprocess.call, ['ovs-vsctl', '-t', '5', '--if-exists', 'del-br', 'ovsbr'])
++        self.addCleanup(subprocess.call, ['ovs-vsctl', '-t', '5', 'del-ssl'])
+         with open(self.config, 'w') as f:
+             f.write('''network:
+   ethernets:
+@@ -282,7 +282,7 @@ class _CommonTests():
+ ''' % {'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
+         self.generate_and_settle([self.dev_e_client, self.dev_e2_client, 'ovsbr'])
+         # Basic verification that the interfaces/ports are in OVS
+-        out = subprocess.check_output(['ovs-vsctl', 'show'])
++        out = subprocess.check_output(['ovs-vsctl', '-t', '5', 'show'])
+         self.assertIn(b'    Bridge ovsbr', out)
+         self.assertIn(b'        Controller "tcp:127.0.0.1"', out)
+         self.assertIn(b'        Controller "pssl:1337:[::1]"', out)
+@@ -291,15 +291,15 @@ class _CommonTests():
+         self.assertIn(b'        Port %(ec)b\n            Interface %(ec)b' % {b'ec': self.dev_e_client.encode()}, out)
+         self.assertIn(b'        Port %(e2c)b\n            Interface %(e2c)b' % {b'e2c': self.dev_e2_client.encode()}, out)
+         # Verify the bridge was tagged 'netplan:true' correctly
+-        out = subprocess.check_output(['ovs-vsctl', '--columns=name,external-ids', '-f', 'csv', '-d', 'bare',
++        out = subprocess.check_output(['ovs-vsctl', '-t', '5', '--columns=name,external-ids', '-f', 'csv', '-d', 'bare',
+                                        'list', 'Bridge', 'ovsbr'])
+         self.assertIn(b'netplan=true', out)
+         self.assert_iface('ovsbr', ['inet 192.170.1.1/24'])
+ 
+     def test_bond_base(self):
+         self.setup_eth(None, False)
+-        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'ovsbr'])
+-        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-port', 'mybond'])
++        self.addCleanup(subprocess.call, ['ovs-vsctl', '-t', '5', '--if-exists', 'del-br', 'ovsbr'])
++        self.addCleanup(subprocess.call, ['ovs-vsctl', '-t', '5', '--if-exists', 'del-port', 'mybond'])
+         with open(self.config, 'w') as f:
+             f.write('''network:
+   ethernets:
+@@ -318,13 +318,14 @@ class _CommonTests():
+       interfaces: [mybond]''' % {'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
+         self.generate_and_settle([self.dev_e_client, self.dev_e2_client, 'ovsbr'])
+         # Basic verification that the interfaces/ports are in OVS
+-        out = subprocess.check_output(['ovs-vsctl', 'show'])
++        out = subprocess.check_output(['ovs-vsctl', '-t', '5', 'show'])
+         self.assertIn(b'    Bridge ovsbr', out)
+         self.assertIn(b'        Port mybond', out)
+         self.assertIn(b'            Interface %b' % self.dev_e_client.encode(), out)
+         self.assertIn(b'            Interface %b' % self.dev_e2_client.encode(), out)
+         # Verify the bond was tagged 'netplan:true' correctly
+-        out = subprocess.check_output(['ovs-vsctl', '--columns=name,external-ids', '-f', 'csv', '-d', 'bare', 'list', 'Port'])
++        out = subprocess.check_output(['ovs-vsctl', '-t', '5', '--columns=name,external-ids', '-f', 'csv',
++                                       '-d', 'bare', 'list', 'Port'])
+         self.assertIn(b'mybond,netplan=true', out)
+         # Verify bond params
+         out = subprocess.check_output(['ovs-appctl', 'bond/show', 'mybond'])
+@@ -337,10 +338,10 @@ class _CommonTests():
+ 
+     def test_bridge_patch_ports(self):
+         self.setup_eth(None)
+-        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'br0'])
+-        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'br1'])
+-        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-port', 'patch0-1'])
+-        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-port', 'patch1-0'])
++        self.addCleanup(subprocess.call, ['ovs-vsctl', '-t', '5', '--if-exists', 'del-br', 'br0'])
++        self.addCleanup(subprocess.call, ['ovs-vsctl', '-t', '5', '--if-exists', 'del-br', 'br1'])
++        self.addCleanup(subprocess.call, ['ovs-vsctl', '-t', '5', '--if-exists', 'del-port', 'patch0-1'])
++        self.addCleanup(subprocess.call, ['ovs-vsctl', '-t', '5', '--if-exists', 'del-port', 'patch1-0'])
+         with open(self.config, 'w') as f:
+             f.write('''network:
+   openvswitch:
+@@ -355,7 +356,7 @@ class _CommonTests():
+       interfaces: [patch1-0]''')
+         self.generate_and_settle(['br0', 'br1'])
+         # Basic verification that the interfaces/ports are set up in OVS
+-        out = subprocess.check_output(['ovs-vsctl', 'show'])
++        out = subprocess.check_output(['ovs-vsctl', '-t', '5', 'show'])
+         self.assertIn(b'    Bridge br0', out)
+         self.assertIn(b'''        Port patch0-1
+             Interface patch0-1
+@@ -371,7 +372,7 @@ class _CommonTests():
+ 
+     def test_bridge_non_ovs_bond(self):
+         self.setup_eth(None, False)
+-        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'ovs-br'])
++        self.addCleanup(subprocess.call, ['ovs-vsctl', '-t', '5', '--if-exists', 'del-br', 'ovs-br'])
+         self.addCleanup(subprocess.call, ['ip', 'link', 'del', 'non-ovs-bond'])
+         with open(self.config, 'w') as f:
+             f.write('''network:
+@@ -388,7 +389,7 @@ class _CommonTests():
+             openvswitch: {}''' % {'ec': self.dev_e_client, 'e2c': self.dev_e2_client})
+         self.generate_and_settle([self.dev_e_client, self.dev_e2_client, 'ovs-br', 'non-ovs-bond'])
+         # Basic verification that the interfaces/ports are set up in OVS
+-        out = subprocess.check_output(['ovs-vsctl', 'show'], universal_newlines=True)
++        out = subprocess.check_output(['ovs-vsctl', '-t', '5', 'show'], universal_newlines=True)
+         self.assertIn('    Bridge ovs-br', out)
+         self.assertIn('''        Port non-ovs-bond
+             Interface non-ovs-bond''', out)
+@@ -401,7 +402,7 @@ class _CommonTests():
+ 
+     def test_vlan_maas(self):
+         self.setup_eth(None, False)
+-        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'ovs0'])
++        self.addCleanup(subprocess.call, ['ovs-vsctl', '-t', '5', '--if-exists', 'del-br', 'ovs0'])
+         self.addCleanup(subprocess.call, ['ip', 'link', 'delete', '%s.21' % self.dev_e_client], stderr=subprocess.DEVNULL)
+         with open(self.config, 'w') as f:
+             f.write('''network:
+@@ -434,7 +435,7 @@ class _CommonTests():
+             mtu: 1500''' % {'ec': self.dev_e_client})
+         self.generate_and_settle([self.dev_e_client, 'ovs0', 'eth42.21'])
+         # Basic verification that the interfaces/ports are set up in OVS
+-        out = subprocess.check_output(['ovs-vsctl', 'show'], universal_newlines=True)
++        out = subprocess.check_output(['ovs-vsctl', '-t', '5', 'show'], universal_newlines=True)
+         self.assertIn('    Bridge ovs0', out)
+         self.assertIn('''        Port %(ec)s.21
+             Interface %(ec)s.21''' % {'ec': self.dev_e_client}, out)
+@@ -466,9 +467,9 @@ class _CommonTests():
+ 
+     def test_settings_tag_cleanup(self):
+         self.setup_eth(None, False)
+-        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'ovs0'])
+-        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-br', 'ovs1'])
+-        self.addCleanup(subprocess.call, ['ovs-vsctl', '--if-exists', 'del-port', 'bond0'])
++        self.addCleanup(subprocess.call, ['ovs-vsctl', '-t', '5', '--if-exists', 'del-br', 'ovs0'])
++        self.addCleanup(subprocess.call, ['ovs-vsctl', '-t', '5', '--if-exists', 'del-br', 'ovs1'])
++        self.addCleanup(subprocess.call, ['ovs-vsctl', '-t', '5', '--if-exists', 'del-port', 'bond0'])
+         with open(self.config, 'w') as f:
+             f.write('''network:
+   version: 2

--- a/recipes-connectivity/netplan/netplan_0.104.bbappend
+++ b/recipes-connectivity/netplan/netplan_0.104.bbappend
@@ -1,0 +1,6 @@
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://0001-fix-infinite-timeouts-in-ovs-vsctl.patch"


### PR DESCRIPTION
Backport of the following upstream commit:
https://github.com/canonical/netplan/commit/62f0a75e8e69149578bef1007cc808810b3440d3