### PR TITLE
flash: add persistent partition sanity check

### DIFF
--- a/recipes-seapath/flash-script/files/flash.sh
+++ b/recipes-seapath/flash-script/files/flash.sh
@@ -111,6 +111,9 @@ parted -s -- "${disk}" resizepart "${LAST_PART}" "${END}"
 echo "Update file system to the new partition size"
 resize2fs "${OVERLAY}"
 
+# Sanity check
+e2fsck -fp "${OVERLAY}"
+
 # Check if efivarfs is mounted
 if ! grep -q /sys/firmware/efi/efivars /proc/mounts ; then
     mount -t efivarfs efivarfs /sys/firmware/efi/efivars

--- a/recipes-seapath/flash-script/flash-script.bb
+++ b/recipes-seapath/flash-script/flash-script.bb
@@ -10,7 +10,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
 
 SRCREV = "${AUTOREV}"
-RDEPENDS:${PN} = "bash e2fsprogs-resize2fs gptfdisk parted"
+RDEPENDS:${PN} = "bash e2fsprogs-e2fsck e2fsprogs-resize2fs gptfdisk parted"
 
 PACKAGES += "${PN}-auto"
 


### PR DESCRIPTION
Depending on the disk we are flashing Seapath, and particularly NVME disks, errors can occur during persistent partition resize (orphan block).
To make sure integrity of persistent partition is OK, add a sanity check of it using e2fsck.