### PR TITLE
Create livemigration user and libvirt group at build time

### DIFF
--- a/recipes-cukinia-tests/cukinia-tests/files/hypervisor_security_tests.d/groups.conf
+++ b/recipes-cukinia-tests/cukinia-tests/files/hypervisor_security_tests.d/groups.conf
@@ -43,6 +43,8 @@ groups=" \
     snmp \
     sgx \
     render \
+    livemigration \
+    libvirt \
 "
 args="-v"
 for g in ${groups}; do

--- a/recipes-cukinia-tests/cukinia-tests/files/hypervisor_security_tests.d/passwd.conf
+++ b/recipes-cukinia-tests/cukinia-tests/files/hypervisor_security_tests.d/passwd.conf
@@ -20,6 +20,7 @@ passwd=" \
     nobody \
     openvswitch \
     snmp \
+    livemigration \
 "
 args="-v"
 for g in ${passwd}; do

--- a/recipes-cukinia-tests/cukinia-tests/files/hypervisor_security_tests.d/shadow.conf
+++ b/recipes-cukinia-tests/cukinia-tests/files/hypervisor_security_tests.d/shadow.conf
@@ -8,6 +8,7 @@ unlocked_users=" \
     root \
     admin \
     emergadmin \
+    livemigration \
 "
 
 locked_users=" \

--- a/recipes-extended/libvirt/libvirt_%.bbappend
+++ b/recipes-extended/libvirt/libvirt_%.bbappend
@@ -10,6 +10,8 @@ SERVICE_DIRS_OWNER = "root:root"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
+GROUPADD_PARAM:${PN}:append = "; -r libvirt"
+
 SRC_URI += " \
     file://libvirtd \
     file://libvirtd.conf \

--- a/recipes-seapath/system-config/system-config.bb
+++ b/recipes-seapath/system-config/system-config.bb
@@ -11,6 +11,9 @@ RDEPENDS:${PN}-security = "bash"
 RDEPENDS:${PN}-cluster= "python3-setup-ovs openvswitch"
 RDEPENDS:${PN}-common= "${PN}-keymap"
 
+# Add DEPENDS required for create the livemigration user
+DEPENDS += "libvirt qemu pacemaker"
+
 SRC_URI = " \
     file://common/90-sysctl-hardening.conf \
     file://common/99-sysctl-network.conf \
@@ -24,6 +27,13 @@ SRC_URI = " \
     file://host/rt-runtime-share.service \
     file://security/disable-local-login.sh \
     file://test/usb-cdc-acm.conf \
+"
+
+USERADD_PACKAGES = "${PN}-cluster"
+USERADD_PARAM:${PN}-cluster = "\
+    --system \
+    -G haclient,libvirt \
+    -N livemigration \
 "
 
 do_install () {
@@ -111,7 +121,7 @@ SYSTEMD_SERVICE:${PN}-host = " \
 
 REQUIRED_DISTRO_FEATURES = "systemd"
 
-inherit allarch systemd features_check
+inherit allarch systemd features_check useradd
 
 FILES:${PN}-common = " \
     ${sysconfdir}/sysctl.d/99-sysctl-network.conf \


### PR DESCRIPTION
To avoid creating the livemigration user and the libvirt group by Ansible modify meta-seapath to create it during the build.

It is still needed to use Ansible to be able to use the livemigration user, only the creation is done by Yocto.