### PR TITLE
seapath-flasher-cpio: increase INITRAMFS_MAXSIZE to 512Mb

### DIFF
--- a/recipes-core/images/seapath-flasher-cpio.bb
+++ b/recipes-core/images/seapath-flasher-cpio.bb
@@ -46,4 +46,4 @@ inherit ansible-ssh
 COMPATIBLE_MACHINE = "seapath-installer"
 
 # 256MB
-INITRAMFS_MAXSIZE = "400000"
+INITRAMFS_MAXSIZE = "512000"


### PR DESCRIPTION
As we add recently some packages in flash image, increase the size of the initramfs image.