### PR TITLE
scarthgap: distro: disable buildhistory

### DIFF
--- a/conf/distro/seapath-common.inc
+++ b/conf/distro/seapath-common.inc
@@ -26,10 +26,6 @@ DISTRO_FEATURES:remove = " wayland"
 DISTRO_FEATURES:remove = " 3g alsa bluetooth nfc nfs opengl pcmcia vulkan wifi zeroconf"
 DISTRO_FEATURES_BACKFILL_CONSIDERED += "pulseaudio"
 
-# Active buildhistory
-INHERIT += "buildhistory"
-BUILDHISTORY_COMMIT = "1"
-
 # Use virtualization features
 DISTRO_FEATURES:append = " virtualization"
 DISTRO_FEATURES:append = " kvm"

--- a/conf/distro/seapath-flash.conf
+++ b/conf/distro/seapath-flash.conf
@@ -12,10 +12,6 @@ DISTRO = "seapath-flash"
 DISTRO_NAME = "Seapath Flash Yocto distribution"
 DISTRO_VERSION = "1.0"
 
-# Active buildhistory
-INHERIT += "buildhistory"
-BUILDHISTORY_COMMIT = "1"
-
 # Enable Ansible SSH key copy
 DISTRO_FEATURES:append = " ansible"
 


### PR DESCRIPTION
Remove the global inheritance to the buildhistory class.

It creates a non-deterministic problem when removing the build directory shortly after finishing the build:
"rm: cannot remove build/buildhistory/.git': Directory not empty". This is a problem for CI builds as they remove the build directory between each image build.