### PR TITLE
distro: fix typo in REQUIRED_VERSION

### DIFF
--- a/conf/distro/seapath-common.inc
+++ b/conf/distro/seapath-common.inc
@@ -101,5 +101,5 @@ GROUPADD_GID_TABLES = "conf/distro/include/group.gid"
 
 # Ceph do not support the rocksdb version 9 provide by meta-oe
 # So we need to use a earlier version
-REQUIERED_VERSION_rocksdb = "6.20.%"
-REQUIERED_VERSION_python3-cython = "0.29.35"
+REQUIRED_VERSION_rocksdb = "6.20.%"
+REQUIRED_VERSION_python3-cython = "0.29.%"

--- a/conf/distro/seapath-host-common.inc
+++ b/conf/distro/seapath-host-common.inc
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Savoir-faire Linux, Inc.
+# Copyright (C) 2023-2024 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 DISTROOVERRIDES =. "seapath-host:"
@@ -8,4 +8,4 @@ require conf/distro/seapath-common.inc
 # Enable dpdk for openvswitch
 PACKAGECONFIG:append:pn-openvswitch = " dpdk"
 COMPATIBLE_MACHINE:pn-dpdk = "(seapath)"
-REQUIERED_VERSION_dpdk = "21.11.%"
+REQUIRED_VERSION_dpdk = "23.11.%"


### PR DESCRIPTION
The variable REQUIRED_VERSION was misspelled as REQUIERED_VERSION in seapath-common.inc and seapath-host-common.inc. This commit fixes the typo and update the version of dpdk to 23.11.%.