### PR TITLE
distro/seapath-host-common: fix typo in REQUIRED_VERSION_dpdk

### DIFF
--- a/conf/distro/seapath-host-common.inc
+++ b/conf/distro/seapath-host-common.inc
@@ -8,4 +8,4 @@ require conf/distro/seapath-common.inc
 # Enable dpdk for openvswitch
 PACKAGECONFIG:append:pn-openvswitch = " dpdk"
 COMPATIBLE_MACHINE:pn-dpdk = "(seapath)"
-REQUIERED_VERSION_dpdk = "21.11.%"
+REQUIRED_VERSION_dpdk = "21.11.%"


### PR DESCRIPTION
The variable REQUIRED_VERSION_dpdk was misspelled as REQUIERED_VERSION_dpdk.