### PR TITLE
ceph: fix parallel build to 8

### DIFF
--- a/recipes-extended/ceph/ceph_16.%.bbappend
+++ b/recipes-extended/ceph/ceph_16.%.bbappend
@@ -49,9 +49,7 @@ PACKAGE_BEFORE_PN = "\
 
 
 def limit_parallel(d):
-    import multiprocessing
-    return "-j{}".format(d.getVar("SEAPATH_PARALLEL_MAKE",
-                                  multiprocessing.cpu_count()))
+    return "-j{}".format(d.getVar("SEAPATH_PARALLEL_MAKE",8))
 
 PARALLEL_MAKE = "${@limit_parallel(d)}"
 


### PR DESCRIPTION
The multiprocessing module do not work in the bitbake environment on scarthgap. Hardcode the default number of parallel build to 8.