### PR TITLE
ceph: fix /var/lib/ceph insufficient permissions

### DIFF
--- a/recipes-extended/ceph/ceph_16.%.bbappend
+++ b/recipes-extended/ceph/ceph_16.%.bbappend
@@ -60,7 +60,7 @@ do_install:append () {
     for directory in mon osd mds tmp radosgw bootstrap-rgw bootstrap-mgr \
         bootstrap-mds bootstrap-osd bootstrap-rbd bootstrap-rbd-mirror
     do
-        install -m 0755 -d ${D}${localstatedir}/lib/ceph/${directory}
+        install -m 0755 -o ceph -g ceph -d ${D}${localstatedir}/lib/ceph/${directory}
     done
 
     install -m 0755 -d ${D}${localstatedir}/log/ceph


### PR DESCRIPTION
Directories created inside /var/lib/ceph must have ceph as group and owner. If not, ceph monitor services will produce errors.