### PR TITLE
cluster-glue: system-config-cluster: set USERADD_DEPENDS

### DIFF
--- a/recipes-cgl/cluster-glue/cluster-glue_%.bbappend
+++ b/recipes-cgl/cluster-glue/cluster-glue_%.bbappend
@@ -3,7 +3,7 @@
 
 #to add hacluster to the msmtp group, so that it can write to msmtp log file
 RDEPENDS:${PN} += "msmtp"
-DEPENDS += "msmtp"
+USERADD_DEPENDS = "msmtp"
 USERADD_PARAM:${PN}:prepend = " -G msmtp "
 
 do_install:append() {

--- a/recipes-seapath/system-config/system-config-cluster.bb
+++ b/recipes-seapath/system-config/system-config-cluster.bb
@@ -9,9 +9,6 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7ca
 SRCREV = "${AUTOREV}"
 RDEPENDS:${PN} = "python3-setup-ovs openvswitch libvirt pacemaker"
 
-# Add DEPENDS required for create the livemigration user
-DEPENDS += "libvirt pacemaker"
-
 SRC_URI = " \
     file://openvswitch.conf \
     file://seapath-config_ovs.service \
@@ -23,6 +20,7 @@ USERADD_PARAM:${PN} = "\
     -G haclient,libvirt \
     -M livemigration \
 "
+USERADD_DEPENDS = "libvirt pacemaker"
 
 do_install () {
 


### PR DESCRIPTION
Some builds (CI or manual) encounter an error were the do_package_setscene task of recipes depending on groups created by other recipes fail because useradd can't find the groups. This error was already reported on the yocto bugzilla [1].

With scarthgap, commit [2] of poky introduced the new variable USERADD_DEPENDS to fix this issue. It adds the listed recipes to DEPENDS and creates additional task dependencies to fix the issue.

Use this variable with cluster-glue bbappend and system-config-cluster recipe, as the problem was frequently encountered with these recipes.

[1]: https://bugzilla.yoctoproject.org/show_bug.cgi?id=13419
[2]: https://git.yoctoproject.org/poky/commit/?id=ecef665062be55fcfa0915216335d08883aa86f7