### PR TITLE
qemu: add vhost PACKAGECONFIG

### DIFF
--- a/recipes-devtools/qemu/qemu_%.bbappend
+++ b/recipes-devtools/qemu/qemu_%.bbappend
@@ -4,4 +4,4 @@
 EXTRA_OECONF:append:class-target = "${@bb.utils.contains('DISTRO_FEATURES','seapath-clustering', " --enable-rbd", "",d)}"
 DEPENDS:append:class-target = "${@bb.utils.contains('DISTRO_FEATURES','seapath-clustering'," ceph", "",d)}"
 
-PACKAGECONFIG:append = " libusb"
+PACKAGECONFIG:append = " libusb vhost"


### PR DESCRIPTION
Following the scarthgap update, qemu won't compile support for vhost-net drivers without the appropriate PACKAGECONFIG. However, this is required for the creation of the bridge with the protection VMs specified in their XML.

Add the required vhost PACKAGECONFIG for qemu.