### PR TITLE
images/seapath-common: explicitly install os-release

### DIFF
--- a/recipes-core/images/seapath-common.inc
+++ b/recipes-core/images/seapath-common.inc
@@ -11,6 +11,7 @@ IMAGE_INSTALL:append = " \
     ${@bb.utils.contains('DISTRO_FEATURES','seapath-security','cukinia-tests-common-security','',d)} \
     linuxptp \
     netplan \
+    os-release \
     system-config-common \
 "
 # Add kernel-modules


### PR DESCRIPTION
os-release was installed through RRECOMMENDS by the systemd recipe. As content of the /etc/os-release file will now be used by Seapath ansible to detect the Yocto distribution, explicitly install os-release on Seapath images.