### PR TITLE
scarthgap: add docker system tests

### DIFF
--- a/recipes-cukinia-tests/cukinia-tests/files/hypervisor_security_tests.d/groups.conf
+++ b/recipes-cukinia-tests/cukinia-tests/files/hypervisor_security_tests.d/groups.conf
@@ -3,47 +3,47 @@
 # SPDX-License-Identifier: Apache-2.0
 
 groups=" \
-    root \
-    daemon \
-    tty \
-    disk \
-    shadow \
-    utmp \
-    video \
-    shutdown \
-    users \
-    kvm \
-    qemu \
-    systemd-timesync \
-    systemd-resolve \
-    systemd-network \
-    systemd-journal \
-    ceph \
-    sshd \
-    messagebus \
-    haclient \
     admin \
-    privileged \
-    ansible \
-    operator \
-    maint-n1 \
-    maint-n3 \
     admincluster \
     adminsys \
+    ansible \
+    ceph \
+    daemon \
+    disk \
     emergadmin \
-    msmtp \
-    nogroup \
-    wheel \
-    input \
-    nobody \
-    openvswitch \
-    vfio-net \
+    haclient \
     hugepages \
-    snmp \
-    sgx \
-    render \
-    livemigration \
+    input \
+    kvm \
     libvirt \
+    livemigration \
+    maint-n1 \
+    maint-n3 \
+    messagebus \
+    msmtp \
+    nobody \
+    nogroup \
+    openvswitch \
+    operator \
+    privileged \
+    qemu \
+    render \
+    root \
+    sgx \
+    shadow \
+    shutdown \
+    snmp \
+    sshd \
+    systemd-journal \
+    systemd-network \
+    systemd-resolve \
+    systemd-timesync \
+    tty \
+    users \
+    utmp \
+    vfio-net \
+    video \
+    wheel \
 "
 args="-v"
 for g in ${groups}; do

--- a/recipes-cukinia-tests/cukinia-tests/files/hypervisor_security_tests.d/groups.conf
+++ b/recipes-cukinia-tests/cukinia-tests/files/hypervisor_security_tests.d/groups.conf
@@ -10,6 +10,7 @@ groups=" \
     ceph \
     daemon \
     disk \
+    docker \
     emergadmin \
     haclient \
     hugepages \


### PR DESCRIPTION
The docker group wasn't added following default installation of docker, this PR add it