### PR TITLE
seapath-observer-common.inc: add SNMP to the observer

### DIFF
--- a/recipes-core/images/seapath-observer-common.inc
+++ b/recipes-core/images/seapath-observer-common.inc
@@ -6,6 +6,8 @@ USERS_LIST_LOCKED:remove = "qemu"
 
 IMAGE_INSTALL:append = " \
     cukinia-tests-observer \
+    net-snmp-server \
+    net-snmp-client \
     system-upgrade \
     system-config-cluster \
     ${@bb.utils.contains('DISTRO_FEATURES', 'seapath-security', 'system-config-security', '', d)} \


### PR DESCRIPTION
The SNMP protocol can be used to monitor cluster data from the observer, so the SNMP agent must be added to it's image.