### PR TITLE
ssh: reset authorized_keys path to the regular one (kirkstone)

### DIFF
--- a/classes/ansible-ssh.bbclass
+++ b/classes/ansible-ssh.bbclass
@@ -19,15 +19,11 @@ do_add_ansible_ssh_key() {
             bbwarn "User $user does not exist in destination image. Skipped"
             continue
         fi
-        install -m 0755 -d ${IMAGE_ROOTFS}/${sysconfdir}/ssh/$user
+        install -m 0700 -d ${IMAGE_ROOTFS}/home/${user}/.ssh
         install -m 0600 ${AUTHORIZED_KEYS_DIR}/ansible-authorized_keys \
-                        ${IMAGE_ROOTFS}/${sysconfdir}/ssh/$user/authorized_keys
+                       ${IMAGE_ROOTFS}/home/${user}/.ssh/authorized_keys
 
-        eval flock -x ${IMAGE_ROOTFS}/${sysconfdir} -c \"$PSEUDO chown -R $user:$user ${IMAGE_ROOTFS}/etc/ssh/$user \"
-        sed -i "s#AuthorizedKeysFile.*#AuthorizedKeysFile	/etc/ssh/%u/authorized_keys#" \
-                        ${IMAGE_ROOTFS}/${sysconfdir}/ssh/sshd_config
-        sed -i "s#AuthorizedKeysFile.*#AuthorizedKeysFile	/etc/ssh/%u/authorized_keys#" \
-                        ${IMAGE_ROOTFS}/${sysconfdir}/ssh/sshd_config_readonly
+        eval flock -x ${IMAGE_ROOTFS}/home/${user} -c \"$PSEUDO chown -R $user:$user ${IMAGE_ROOTFS}/home/${user}/.ssh \"
     done
     sed -i "s/^UsePAM*/#UsePAM/g" \
         ${IMAGE_ROOTFS}/${sysconfdir}/ssh/sshd_config_readonly

--- a/recipes-connectivity/openssh/files/sshd_config_seapath
+++ b/recipes-connectivity/openssh/files/sshd_config_seapath
@@ -30,7 +30,7 @@ PasswordAuthentication no
 KbdInteractiveAuthentication no
 ChallengeResponseAuthentication no
 AuthenticationMethods publickey
-AuthorizedKeysFile	/etc/ssh/%u/authorized_keys
+AuthorizedKeysFile	.ssh/authorized_keys
 PermitEmptyPasswords no
 AllowAgentForwarding no
 AllowTcpForwarding no

--- a/recipes-seapath/system-config/system-config-cluster.bb
+++ b/recipes-seapath/system-config/system-config-cluster.bb
@@ -22,6 +22,7 @@ USERADD_PARAM:${PN} = "\
     --system \
     -b /var/lib \
     -m \
+    -p '*' \
     -G haclient,libvirt \
     livemigration \
 "

--- a/recipes-seapath/system-config/system-config-cluster.bb
+++ b/recipes-seapath/system-config/system-config-cluster.bb
@@ -20,8 +20,10 @@ SRC_URI = " \
 USERADD_PACKAGES = "${PN}"
 USERADD_PARAM:${PN} = "\
     --system \
+    -b /var/lib \
+    -m \
     -G haclient,libvirt \
-    -M livemigration \
+    livemigration \
 "
 
 do_install () {


### PR DESCRIPTION
The authorized_keys file path was changed to /etc/ssh/%u/authorized_keys for unknown reasons. This changed overcomplicates the configuration.

This commit resets the authorized_keys file path to the regular one ~/.ssh/authorized_keys.
