### PR TITLE
base-passwd/group: fix group

### DIFF
--- a/recipes-core/base-passwd/base-passwd/group.master
+++ b/recipes-core/base-passwd/base-passwd/group.master
@@ -3,10 +3,13 @@ daemon:*:1:
 tty:*:5:
 disk:*:6:
 mail:*:8:
+input:*:19:
 shadow:*:42:
 utmp:*:43:
 video:*:44:
 kvm:*:47:
-shutdown:*:61
+shutdown:*:61:
 users:*:100:
+wheel:*:982:
+sgx:*:998:
 nogroup:*:65534:


### PR DESCRIPTION
To avoid errors from eudev/udev we need a sgx and an input groups.
  
To avoid a warning during the build, we need to add the wheel group.
  
Also, we need to add a colon at the end of the shutdown group.