### PR TITLE
recipes-extended/libvirt: remove ProtectKernelModules

### DIFF
--- a/recipes-extended/libvirt/files/libvirtd.service.fragment
+++ b/recipes-extended/libvirt/files/libvirtd.service.fragment
@@ -7,7 +7,6 @@ EnvironmentFile=/etc/sysconfig/libvirtd
 # Sandboxing
 PrivateTmp=yes
 NoNewPrivileges=true
-ProtectKernelModules=yes
 ProtectKernelTunables=no
 ProtectControlGroups=no
 RestrictSUIDSGID=true


### PR DESCRIPTION
libvirt need to access to the modules.alias file. The ProtectKernelModules block this access and prevent libvirt to start VMs.

Remove the ProtectKernelModules option from the libvirtd.service file. The module loading is already protected by the seccomp profile.