### PR TITLE
seapath-host-common-virtu: add iproute2-tc to the images

### DIFF
--- a/recipes-core/images/seapath-host-common-virtu.inc
+++ b/recipes-core/images/seapath-host-common-virtu.inc
@@ -13,4 +13,5 @@ IMAGE_INSTALL:append = " \
     openvswitch \
     qemu \
     libxml2-utils \
+    iproute2-tc \
 "


### PR DESCRIPTION
tc is needed by libvirt to set network rules. If tc is not present, libvirt raises a non-blocking error.

Change-Id: I7488e56b6a4cd4d11e4efecd1588b836189d7a2c