### PR TITLE
Fix swupdate rollback

### DIFF
--- a/recipes-core/images/files/swupdate_install.sh
+++ b/recipes-core/images/files/swupdate_install.sh
@@ -64,11 +64,13 @@ do_postinst()
 {
     echo "Post-Install:"
 
+    # Make sure current slot's bootloader is not mounted
+    umount -fq /boot || true
+
     # Update grubenv
     if ! mount -t vfat /dev/upgradable_bootloader /boot ; then
         die "Could not mount /dev/upgradable_bootloader"
     fi
-
 
     if ! grub-editenv /boot/EFI/BOOT/grubenv create ; then
         die "Could not create grubenv"

--- a/recipes-core/images/seapath-common.inc
+++ b/recipes-core/images/seapath-common.inc
@@ -43,6 +43,9 @@ IMAGE_FSTYPES = "wic.gz wic.bmap"
 WKS_FILE = "mkefidisk.wks.in"
 # Do not update fstab file when using wic images
 WIC_CREATE_EXTRA_ARGS += "--no-fstab-update"
+# Just like the wic image, the rootfs tarball (goes in .swu) should not include
+# the boot directory to allow mounting the boot partition on the target
+IMAGE_CMD_TAR:append = " --exclude='boot/*'"
 EXTRA_IMAGE_FEATURES = ""
 
 inherit ${@bb.utils.contains('DISTRO_FEATURES', 'seapath-security', 'security/users', '', d)}

--- a/recipes-seapath/system-config/system-config.bb
+++ b/recipes-seapath/system-config/system-config.bb
@@ -11,6 +11,8 @@ RDEPENDS:${PN}-security = "bash"
 RDEPENDS:${PN}-common= "${PN}-keymap"
 
 SRC_URI = " \
+    file://common/10-erspan0.network \
+    file://common/10-gretap0.network \
     file://common/90-sysctl-hardening.conf \
     file://common/99-sysctl-network.conf \
     file://common/terminal_idle.sh \
@@ -61,6 +63,13 @@ do_install () {
     install -m 0644 ${WORKDIR}/common/90-sysctl-hardening.conf \
         ${D}${sysconfdir}/sysctl.d
 
+# Network
+    install -d ${D}${systemd_unitdir}/network
+    install -m 0644 ${WORKDIR}/common/10-erspan0.network \
+        ${D}${systemd_unitdir}/network
+    install -m 0644 ${WORKDIR}/common/10-gretap0.network \
+        ${D}${systemd_unitdir}/network
+
 # Read-only
     install -d ${D}/${base_sbindir}
     echo '#!/bin/sh\nexec /sbin/init $@' > ${D}/${base_sbindir}/init.sh
@@ -100,6 +109,8 @@ inherit allarch systemd features_check
 FILES:${PN}-common = " \
     ${sysconfdir}/sysctl.d/99-sysctl-network.conf \
     ${systemd_unitdir}/system/var-log.mount \
+    ${systemd_unitdir}/network/10-erspan0.network \
+    ${systemd_unitdir}/network/10-gretap0.network \
 "
 
 FILES:${PN}-keymap = " \

--- a/recipes-seapath/system-config/system-config/common/10-erspan0.network
+++ b/recipes-seapath/system-config/system-config/common/10-erspan0.network
@@ -1,0 +1,5 @@
+[Match]
+Name=erspan0
+
+[Link]
+Unmanaged=yes

--- a/recipes-seapath/system-config/system-config/common/10-gretap0.network
+++ b/recipes-seapath/system-config/system-config/common/10-gretap0.network
@@ -1,0 +1,5 @@
+[Match]
+Name=gretap0
+
+[Link]
+Unmanaged=yes

--- a/recipes-seapath/system-upgrade/files/mount_boot.sh
+++ b/recipes-seapath/system-upgrade/files/mount_boot.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Copyright (C) 2021, RTE (http://www.rte-france.com)
+# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Mount or unmount the /boot partition
+# Usage: mount-boot.sh [mount|umount]
+
+# Get disk name and partition num for current mounted rootfs
+rootfs_part=$(mount | awk '/\/ / { print $1 }')
+disk_name="${rootfs_part: : -1}"
+part_num="${rootfs_part:(-1)}"
+
+# Deduce inactive bank partitions (static association)
+if [[ "${part_num}" == "3" ]] ; then
+    bootloader_part="${disk_name}1"
+else
+    bootloader_part="${disk_name}2"
+fi
+
+if [[ -z "$1" || "$1" == "mount"  ]] ; then
+    mount "${bootloader_part}" /boot 2>/dev/null
+elif [[ "$1" == "umount" ]] ; then
+    umount /boot
+fi

--- a/recipes-seapath/system-upgrade/files/swupdate_check.service
+++ b/recipes-seapath/system-upgrade/files/swupdate_check.service
@@ -3,9 +3,11 @@
 
 [Unit]
 Description="Check the update status"
+After=network-online.target
 
 [Service]
 Type=oneshot
+RemainAfterExit=true
 ExecStart=/usr/share/update/swupdate_check.sh
 
 [Install]

--- a/recipes-seapath/system-upgrade/files/swupdate_check.sh
+++ b/recipes-seapath/system-upgrade/files/swupdate_check.sh
@@ -3,26 +3,15 @@
 # Copyright (C) 2023 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-# Get disk name and partition num for current mounted rootfs
-rootfs_part=$(mount | awk '/\/ / { print $1 }')
-disk_name="${rootfs_part: : -1}"
-part_num="${rootfs_part:(-1)}"
+/usr/share/update/mount_boot.sh mount
 
-# Deduce inactive bank partitions (static association)
-if [[ "${part_num}" == "3" ]] ; then
-    bootloader_part="${disk_name}1"
-else
-    bootloader_part="${disk_name}2"
-fi
-
-mount "${bootloader_part}" /boot 2>/dev/null
 # The system has been updated
 if [ -f /boot/EFI/BOOT/grubenv ] ; then
     if ! /usr/share/update/check-health.sh ; then
         echo "Update tests haves failed" 1>&2
         echo "Rebooting to the last working state..."
         grub-editenv /boot/EFI/BOOT/grubenv set "bootcount=4"
-        umount /boot
+        /usr/share/update/mount_boot.sh umount
         reboot
         exit 1
     else
@@ -33,7 +22,8 @@ if [ -f /boot/EFI/BOOT/grubenv ] ; then
         touch /var/log/update_success
     fi
 fi
-umount /boot
+
+/usr/share/update/mount_boot.sh umount
 if [ -f /var/log/update_marker ] ; then
     # The update have failed
     rm -f /var/log/update_marker

--- a/recipes-seapath/system-upgrade/system-upgrade.bb
+++ b/recipes-seapath/system-upgrade/system-upgrade.bb
@@ -13,6 +13,7 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7ca
 
 SRC_URI = "\
     file://is_from_inactive_bank.sh \
+    file://mount_boot.sh \
     file://partition_symlinks.rules \
     file://switch_bootloader.sh \
     file://swupdate_check.sh \
@@ -37,6 +38,8 @@ do_install () {
         ${D}${datadir}/update/is_from_inactive_bank.sh
     install -m 0644 ${WORKDIR}/partition_symlinks.rules \
         ${D}${sysconfdir}/udev/rules.d
+    install -m 0755 ${WORKDIR}/mount_boot.sh \
+        ${D}${datadir}/update/mount_boot.sh
     install -m 0755 ${WORKDIR}/switch_bootloader.sh \
         ${D}${datadir}/update/switch_bootloader.sh
     install -m 0755 ${WORKDIR}/check-health.sh \
@@ -60,6 +63,7 @@ do_install () {
 FILES:${PN}:append = " \
     ${sysconfdir}/udev/rules.d/partition_symlinks.rules \
     ${datadir}/update/is_from_inactive_bank.sh \
+    ${datadir}/update/mount_boot.sh \
     ${datadir}/update/switch_bootloader.sh \
     ${datadir}/update/check-health.sh \
     ${datadir}/update/swupdate_check.sh \


### PR DESCRIPTION
The boot partition was no longer properly mounted after swupdate. The logic to rollback if a systemd service failed was no longer operating. I also fixed the intended healthcheck to include network connectivity checks.
Note that if Ethernet is not plugged on a networkd managed device, the health check will fail and trigger a swupdate rollback