### PR TITLE
images/seapath-guest-common: add rsync to guest images

### DIFF
--- a/recipes-core/images/seapath-guest-common.inc
+++ b/recipes-core/images/seapath-guest-common.inc
@@ -16,6 +16,7 @@ IMAGE_INSTALL:append = " \
     net-snmp-server \
     net-snmp-client \
     net-snmp-configuration \
+    rsync \
 "
 #add docker
 IMAGE_INSTALL += " \


### PR DESCRIPTION
Ansible synchronize module uses rsync to synchronize files between the host and the guest. This commit adds rsync to the guest images to allow the synchronize module to work.