### PR TITLE
cukinia: security: add cockpit-session to the setuid allowlist

### DIFF
--- a/recipes-cukinia-tests/cukinia-tests/files/common_security_tests.d/files.conf
+++ b/recipes-cukinia-tests/cukinia-tests/files/common_security_tests.d/files.conf
@@ -47,6 +47,7 @@ SETUID_ALLOWLIST="(\
 /usr/bin/su.shadow|\
 /usr/bin/chsh.shadow|\
 /usr/sbin/unix_chkpwd|\
+/usr/libexec/cockpit-session|\
 /usr/libexec/dbus-daemon-launch-helper\
 )"
 id "SEAPATH-00196" as "No unexpected file has setuid/setgid enabled" \


### PR DESCRIPTION
This binary is only present on testing images.