### PR TITLE
Enable PAM for SSH sessions and fix private tmpfs with ansible configuration

### DIFF
--- a/classes/ansible-ssh.bbclass
+++ b/classes/ansible-ssh.bbclass
@@ -25,8 +25,6 @@ do_add_ansible_ssh_key() {
 
         eval flock -x ${IMAGE_ROOTFS}/home/${user} -c \"$PSEUDO chown -R $user:$user ${IMAGE_ROOTFS}/home/${user}/.ssh \"
     done
-    sed -i "s/^UsePAM*/#UsePAM/g" \
-        ${IMAGE_ROOTFS}/${sysconfdir}/ssh/sshd_config_readonly
 }
 
 python() {

--- a/classes/security/artifacts/pam/config/etc/namespace.conf
+++ b/classes/security/artifacts/pam/config/etc/namespace.conf
@@ -1,1 +1,1 @@
-/tmp     /tmp/tmp-inst/       	level      root
+/tmp     /tmp/tmp-inst/       	level      root,@@SEAPATH_PAM_NAMESPACES_EXCLUDE_USERS@@

--- a/classes/security/artifacts/pam/sshd
+++ b/classes/security/artifacts/pam/sshd
@@ -14,3 +14,4 @@ account		requisite	pam_access.so
 session		requisite	pam_keyinit.so force revoke
 session		include		common-session-noninteractive
 session		required	pam_loginuid.so
+session		required	pam_namespace.so

--- a/classes/security/pam-policy.bbclass
+++ b/classes/security/pam-policy.bbclass
@@ -6,6 +6,8 @@
 # Setup and install hardened PAM policy
 #
 
+SEAPATH_PAM_NAMESPACES_EXCLUDE_USERS ?= ""
+
 install_pam_policy() {
     if ${@bb.utils.contains('DISTRO_FEATURES', 'pam', 'true', 'false', d)}; then
         rm --one-file-system -f ${IMAGE_ROOTFS}/etc/pam.d/*
@@ -30,6 +32,9 @@ install_pam_access() {
 
 install_pam_namespace() {
     install -D -m 0640 ${SEC_ARTIFACTS_DIR}/pam/config/etc/namespace.conf ${IMAGE_ROOTFS}/etc/security/namespace.conf
+
+    sed -i 's/@@SEAPATH_PAM_NAMESPACES_EXCLUDE_USERS@@/${@','.join(d.getVar("SEAPATH_PAM_NAMESPACES_EXCLUDE_USERS", True).split())}/g' \
+        ${IMAGE_ROOTFS}/etc/security/namespace.conf
 }
 
 python() {

--- a/classes/security/users-config.inc
+++ b/classes/security/users-config.inc
@@ -31,6 +31,9 @@ USERS_LIST_LOCKED[doc] = "List of users to lock"
 # Configure users with the ansible key enabled
 USERS_SSH_ANSIBLE = "admin"
 
+# Disable polyinstantiated directories for ansible users
+SEAPATH_PAM_NAMESPACES_EXCLUDE_USERS = "${USERS_SSH_ANSIBLE}"
+
 # Additionnal group definition
 GROUPS_LIST ?= "privileged operator maint-n1 maint-n3 admincluster adminsys ansible"
 GROUPS_LIST[doc] = "List of groups to be added"

--- a/recipes-connectivity/openssh/files/sshd-private-tmp.conf
+++ b/recipes-connectivity/openssh/files/sshd-private-tmp.conf
@@ -1,2 +1,0 @@
-[Service]
-PrivateTmp=yes

--- a/recipes-connectivity/openssh/openssh_%.bbappend
+++ b/recipes-connectivity/openssh/openssh_%.bbappend
@@ -6,7 +6,6 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 SRC_URI += " \
     file://sshd_config_seapath \
     file://sshd_config_seapath_flash \
-    file://sshd-private-tmp.conf \
 "
 
 do_install:append() {
@@ -22,10 +21,6 @@ do_install:append() {
         install -m 0644 ${WORKDIR}/sshd_config_seapath \
            ${D}${sysconfdir}/ssh/sshd_config
     fi
-
-    install -d ${D}${systemd_system_unitdir}/sshd@.service.d/
-    install -m 0644 ${WORKDIR}/sshd-private-tmp.conf \
-        ${D}${systemd_system_unitdir}/sshd@.service.d/
 }
 
 do_install:append_seapath-flash() {
@@ -33,3 +28,4 @@ do_install:append_seapath-flash() {
     install -m 0644 ${WORKDIR}/sshd_config_seapath_flash \
         ${D}${sysconfdir}/ssh/sshd_config
 }
+

--- a/recipes-cukinia-tests/cukinia-tests/files/common_security_tests.d/policies.conf
+++ b/recipes-cukinia-tests/cukinia-tests/files/common_security_tests.d/policies.conf
@@ -21,4 +21,4 @@ id "SEAPATH-00169" as "sudo requires password for group ansible (ansible)" not c
 
 id "SEAPATH-00029" as "pam namespaces configured for login" cukinia_cmd grep -q "^session.*required.*pam_namespace.so" /etc/pam.d/login
 id "SEAPATH-00037" as "/tmp namespaces configured" cukinia_cmd grep -q "^/tmp" /etc/security/namespace.conf
-id "SEAPATH-00036" as "private /tmp configured for ssh" cukinia_cmd grep -q "^PrivateTmp=yes" /usr/lib/systemd/system/sshd@.service.d/sshd-private-tmp.conf
+id "SEAPATH-00036" as "pam namespaces configured for sshd" cukinia_cmd grep -q "^session.*required.*pam_namespace.so" /etc/pam.d/sshd


### PR DESCRIPTION
PR https://github.com/seapath/meta-seapath/pull/297 introduce new hardening features to make /tmp private per user as required by some BP28 recommendations.
This was done through PAM configuration for local login, but as PAM was disabled for SSH, systemd option `PrivateTmp` was directly used through the session service `sshd@.service`. However, this raise multiple problems :
- PAM can be used with sshd. That way, the same hardening mechanism can be used for local and ssh logins
- `PrivateTmp` has a slightly different behaviour as the configure `pam_namespace` plugin. With `PrivateTmp`, the `/tmp` directory and session specific mount namespace are deleted on logout, while they persist for later login with `pam_namespace`.
- This private tmpfs feature can prevent some configuration done by SEAPATH ansible. For example, during configuration Ceph will create a tmpfs directory for its OSDs. This tmpfs mount is affected by per-user mount namespaces. It is however easier to exclude a single user (e.g. the ansible user) from `pam_namespace` compared to systemd's `PrivateTmp`

This PR fixes these limitations:
- Re-enable use of PAM for ssh
- Exclude the ansible ssh user from the private tmpfs hardening