### PR TITLE
cukinia: security: add files to ignore while checking /tmp isolation

### DIFF
--- a/recipes-cukinia-tests/cukinia-tests/files/common_security_tests.d/files.conf
+++ b/recipes-cukinia-tests/cukinia-tests/files/common_security_tests.d/files.conf
@@ -27,9 +27,20 @@ id "SEAPATH-00195" as "Ceph OSD are owned by ceph" \
     cukinia_test "$(find /var/lib/ceph/osd -type d -perm -0002 -a \! -user ceph 2>/dev/null || true)" = ""
 
 # Only allowed files in /tmp are systemd-private-* and tmp-inst which belong to private namespaces
+# and also the lock directory created by lvm on cluster images.
+# Also note that, as this test will be running using Ansible, temporarily files created by Cukinia
+# with mktemp should also be excluded.
 # Using systemd-run to escape our current private /tmp namespace
 id "SEAPATH-00011" as "Only polyinstanciated dirs in /tmp" \
-    cukinia_test "$(systemd-run --wait --pipe --collect --quiet find /tmp -maxdepth 1 -a -not -name 'systemd-private-*' -a -not -name 'tmp-inst' 2>/dev/null)" = "/tmp"
+    cukinia_test "$(systemd-run --wait --pipe --collect --quiet \
+        find /tmp -maxdepth 1 \
+            -a -not -name 'systemd-private-*' \
+            -a -not -name 'tmp-inst' \
+            -a -not -name 'lock' \
+            -a -not -name "$(basename $__logfile_tmp)" \
+            -a -not -name "$(basename $__stderr_tmp)" \
+            -a -not -name "$(basename $__stdout_tmp)" \
+        2>/dev/null)" = "/tmp"
 
 # These binaries come from official packages and safely handle setuid
 SETUID_ALLOWLIST="(\


### PR DESCRIPTION
With SEAPATH cluster images, there is an additional "lock" directory created in /tmp by lvm. It should be ignored.

Also, because the Ansible user will run these tests, temporary files created by Cukinia using mktemp should also be ignored. Since [1], Ansible users don't have an isolated /tmp due to limitations regarding hypervisors configuration.

[1]: https://github.com/seapath/meta-seapath/pull/302