### PR TITLE
Fix build SEAPATH Kirkstone

### DIFF
--- a/recipes-seapath/system-config/system-config-livemigration.bb
+++ b/recipes-seapath/system-config/system-config-livemigration.bb
@@ -6,7 +6,7 @@ DESCRIPTION = "Seapath livemigration System configuration"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
 
-inherit useradd
+inherit allarch useradd
 
 RDEPENDS:${PN} = "libvirt pacemaker"
 
@@ -22,3 +22,5 @@ USERADD_PARAM:${PN} = "\
     -G haclient,libvirt \
     livemigration \
 "
+
+ALLOW_EMPTY:${PN} = "1"

--- a/recipes-tools/aaeon-tools/aaeon-tools.bbappend
+++ b/recipes-tools/aaeon-tools/aaeon-tools.bbappend
@@ -1,0 +1,4 @@
+# Copyright (C) 2025, SFL (https://savoirfairelinux.com)
+# SPDX-License-Identifier: Apache-2.0
+
+EXTRA_UBOOT_BOOTLOADER_FILE ?= ""


### PR DESCRIPTION
The previous modifications provided to add the support of the Aaeon I.MX8P board introduced a regression preventing to build x86 images.

The two commits allows to fix an undefined variable on meta-aaeon and generate an empty packet for the system-config-livemigration.