### PR TITLE
recipes-cukinia-tests: fix SEAPATH-00067

### DIFF
--- a/recipes-cukinia-tests/cukinia-tests/files/cluster_tests.d/vm_manager_libvirt.conf
+++ b/recipes-cukinia-tests/cukinia-tests/files/cluster_tests.d/vm_manager_libvirt.conf
@@ -19,9 +19,9 @@ id "SEAPATH-00065" as "list secrets" cukinia_test `/usr/share/testdata/libvirt_c
 id "SEAPATH-00066" as "define VM from a valid configuration" cukinia_cmd \
     /usr/share/testdata/libvirt_cmd.py define /usr/share/testdata/vm.xml
 
-id "SEAPATH-00067" as "define VM from a valid configuration"
 /usr/share/testdata/libvirt_cmd.py define \
     /usr/share/testdata/wrong_vm_config.xml 1>/dev/null 2>&1
+id "SEAPATH-00067" as "define VM from an invalid configuration" \
 cukinia_test $? -ne 0
 
 id "SEAPATH-00068" as "list VM" cukinia_test `/usr/share/testdata/libvirt_cmd.py list \


### PR DESCRIPTION
The SEAPATH-00067 was not displaying correctly in the report. Also, the title was not correct.

Close: #310 