### PR TITLE
system-config: add glibc-utils RDEPENDS to system-config-security

### DIFF
--- a/recipes-seapath/system-config/system-config.bb
+++ b/recipes-seapath/system-config/system-config.bb
@@ -7,7 +7,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
 
 SRCREV = "${AUTOREV}"
-RDEPENDS:${PN}-security = "bash"
+RDEPENDS:${PN}-security = "bash glibc-utils"
 RDEPENDS:${PN}-common= "${PN}-keymap"
 
 SRC_URI = " \


### PR DESCRIPTION
system-config-security is a package which is included when the SEAPATH security feature is enabled. This feature requires the `getent` command, which is provided by the `libc6-utils` package. This commit adds the `glibc-utils` package to the RDEPENDS of the `system-config-security` package. The glic-utils package is the glibc implementation of the `libc6-utils` package.

Close: #311 