### PR TITLE
python3-setup-ovs: avoid package bump

### DIFF
--- a/recipes-seapath/python3-setup-ovs/python3-setup-ovs.bb
+++ b/recipes-seapath/python3-setup-ovs/python3-setup-ovs.bb
@@ -13,3 +13,7 @@ S = "${WORKDIR}/git"
 RDEPENDS:${PN} = "python3 openvswitch python3-pyyaml"
 
 inherit setuptools3
+
+do_install:append() {
+    mv ${D}${bindir}/setup_ovs.py ${D}${bindir}/setup_ovs
+}

--- a/recipes-seapath/system-config/system-config-ovs/seapath-config_ovs.service
+++ b/recipes-seapath/system-config/system-config-ovs/seapath-config_ovs.service
@@ -12,7 +12,7 @@ Requires=ovs-vswitchd.service
 [Service]
 Type=oneshot
 RemainAfterExit=true
-ExecStart=/usr/bin/setup_ovs.py
+ExecStart=/usr/bin/setup_ovs
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The modification [1] on python3-setup-ovs, changes the packaging to use
a pyproject.toml. Changing the version of python3-setup-ovs does not
work as expected on kirkstone (setup_ovs is not generated). This
workaround consist of modifying the file name to match the one used by
Ansible.

[1]: https://github.com/seapath/python3-setup-ovs/commit/f2b575b7cd1c1954f4338d65a83bc88f62e26746