### PR TITLE
recipes-seapath/python3-vm-manager: bump to 8441289

### DIFF
--- a/recipes-cukinia-tests/cukinia-tests/files/cluster_tests.d/vm_manager_libvirt.conf
+++ b/recipes-cukinia-tests/cukinia-tests/files/cluster_tests.d/vm_manager_libvirt.conf
@@ -11,23 +11,24 @@ clean()
 
 clean
 
+python_dir="$(/usr/bin/python3 -c 'import vm_manager as m; print(m.__path__[0])')"
+
 cukinia_log "$(_colorize yellow "--- Test vm_manager module libvirt part ---")"
 
-id "SEAPATH-00065" as "list secrets" cukinia_test `/usr/share/testdata/libvirt_cmd.py secrets \
+id "SEAPATH-00065" as "list secrets" cukinia_test `libvirt_cmd secrets \
     |grep -c client.libvirt` -gt 0
 
 id "SEAPATH-00066" as "define VM from a valid configuration" cukinia_cmd \
-    /usr/share/testdata/libvirt_cmd.py define /usr/share/testdata/vm.xml
+    libvirt_cmd define "${python_dir}/testdata/vm.xml"
 
-/usr/share/testdata/libvirt_cmd.py define \
-    /usr/share/testdata/wrong_vm_config.xml 1>/dev/null 2>&1
+libvirt_cmd define "${python_dir}/testdata/wrong_vm_config.xml" 1>/dev/null 2>&1
 id "SEAPATH-00067" as "define VM from an invalid configuration" \
 cukinia_test $? -ne 0
 
-id "SEAPATH-00068" as "list VM" cukinia_test `/usr/share/testdata/libvirt_cmd.py list \
+id "SEAPATH-00068" as "list VM" cukinia_test `libvirt_cmd list \
     |grep -c "test0"` -gt 0
 
-id "SEAPATH-00069" as "export VM configuration" cukinia_cmd /usr/share/testdata/libvirt_cmd.py \
+id "SEAPATH-00069" as "export VM configuration" cukinia_cmd libvirt_cmd \
     export "test0" /tmp/test_config.xml
 
 id "SEAPATH-00070" as "VM configuration has been export" cukinia_test -f /tmp/test_config.xml

--- a/recipes-cukinia-tests/cukinia-tests/files/cluster_tests.d/vm_manager_pacemaker.conf
+++ b/recipes-cukinia-tests/cukinia-tests/files/cluster_tests.d/vm_manager_pacemaker.conf
@@ -3,10 +3,12 @@
 
 cukinia_log "$(_colorize yellow "--- Test vm_manager module Pacemaker part ---")"
 
-id "SEAPATH-00071" as "Test add VM" cukinia_cmd /usr/share/testdata/add_vm.py
+python_dir="$(/usr/bin/python3 -c 'import vm_manager as m; print(m.__path__[0])')"
 
-id "SEAPATH-00072" as "Test stop VM" cukinia_cmd /usr/share/testdata/stop_vm.py
+id "SEAPATH-00071" as "Test add VM" cukinia_cmd "${python_dir}"/testdata/add_vm.py
 
-id "SEAPATH-00073" as "Test start VM" cukinia_cmd /usr/share/testdata/start_vm.py
+id "SEAPATH-00072" as "Test stop VM" cukinia_cmd "${python_dir}"/testdata/stop_vm.py
 
-id "SEAPATH-00074" as "Test remove VM" cukinia_cmd /usr/share/testdata/remove_vm.py
+id "SEAPATH-00073" as "Test start VM" cukinia_cmd "${python_dir}"/testdata/start_vm.py
+
+id "SEAPATH-00074" as "Test remove VM" cukinia_cmd "${python_dir}"/testdata/remove_vm.py

--- a/recipes-cukinia-tests/cukinia-tests/files/cluster_tests.d/vm_manager_rbd.conf
+++ b/recipes-cukinia-tests/cukinia-tests/files/cluster_tests.d/vm_manager_rbd.conf
@@ -1,18 +1,20 @@
 # Copyright (C) 2021, RTE (http://www.rte-france.com)
 # SPDX-License-Identifier: Apache-2.0
 
+python_dir="$(/usr/bin/python3 -c 'import vm_manager as m; print(m.__path__[0])')"
+
 cukinia_log "$(_colorize yellow "--- Test vm_manager module Ceph RBD part ---")"
 
-id "SEAPATH-00056" as "Test clone disk" cukinia_cmd /usr/share/testdata/clone_rbd.py
+id "SEAPATH-00056" as "Test clone disk" cukinia_cmd "${python_dir}"/testdata/clone_rbd.py
 
-id "SEAPATH-00057" as "Test groups" cukinia_cmd /usr/share/testdata/create_rbd_group.py
+id "SEAPATH-00057" as "Test groups" cukinia_cmd "${python_dir}"/testdata/create_rbd_group.py
 
-id "SEAPATH-00058" as "Test namespaces" cukinia_cmd /usr/share/testdata/create_rbd_namespace.py
+id "SEAPATH-00058" as "Test namespaces" cukinia_cmd "${python_dir}"/testdata/create_rbd_namespace.py
 
-id "SEAPATH-00059" as "Test metadata" cukinia_cmd /usr/share/testdata/metadata_rbd.py
+id "SEAPATH-00059" as "Test metadata" cukinia_cmd "${python_dir}"/testdata/metadata_rbd.py
 
-id "SEAPATH-00060" as "Test snapshots" cukinia_cmd /usr/share/testdata/purge_rbd.py
+id "SEAPATH-00060" as "Test snapshots" cukinia_cmd "${python_dir}"/testdata/purge_rbd.py
 
-id "SEAPATH-00061" as "Test snapshots rollback" cukinia_cmd /usr/share/testdata/rollback_rbd.py
+id "SEAPATH-00061" as "Test snapshots rollback" cukinia_cmd "${python_dir}"/testdata/rollback_rbd.py
 
-id "SEAPATH-00062" as "Test write rbd" cukinia_cmd /usr/share/testdata/write_rbd.py
+id "SEAPATH-00062" as "Test write rbd" cukinia_cmd "${python_dir}"/testdata/write_rbd.py

--- a/recipes-seapath/python3-vm-manager/python3-vm-manager.bb
+++ b/recipes-seapath/python3-vm-manager/python3-vm-manager.bb
@@ -11,27 +11,12 @@ SRC_URI = " \
     file://0001-vm-manager-fix-RADOS-permission-denied-issue.patch \
 "
 
-SRCREV = "dc7d106c011b0458982a2ba3c6b38d26f9046b16"
+SRCREV = "8441289638a855b71fe667aa2cc90380c1753ee0"
 S = "${WORKDIR}/git"
 
 RDEPENDS:${PN} = "python3 libvirt"
 RDEPENDS:${PN} += "${@bb.utils.contains('DISTRO_FEATURES', 'seapath-clustering', "pacemaker ceph", '', d)}"
 
 inherit setuptools3
-
-do_install:append() {
-    # Create testdata directory
-    install -d ${D}/${datadir}/testdata
-
-    # Move python test scripts in testdata
-    mv ${D}/${bindir}/* ${D}/${datadir}/testdata/
-    rm -rf ${D}/${bindir}
-
-    # testdata files
-    install -m 644 ${S}/vm_manager/testdata/* ${D}/${datadir}/testdata/
-
-    # Install CLI tool as "vm-mgr"
-    install -D -m 750 ${S}/vm_manager_cmd.py ${D}/${sbindir}/vm-mgr
-}
 
 FILES:${PN} += "${datadir}/testdata/*"


### PR DESCRIPTION
Update to the latest commit of the python3-vm-manager repository: 8441289638a855b71fe667aa2cc90380c1753ee0.

This commit change the Python packaging to use a pyproject.toml file.

Some path in the test scripts have been updated to use the new path of the testdata directory.