### PR TITLE
classes/security/hardening: add BB_NO_NETWORK support

### DIFF
--- a/classes/security/hardening-config.inc
+++ b/classes/security/hardening-config.inc
@@ -1,5 +1,5 @@
 # Copyright (C) 2021, RTE (http://www.rte-france.com)
-# Copyright (C) 2023 Savoir-faire Linux, Inc.
+# Copyright (C) 2023-2025 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 #
@@ -7,12 +7,15 @@
 # the hardening environment.
 #
 
+BB_NO_NETWORK ??= "0"
+
 SECCOMPILE_MANIFEST ??= ""
 BUILDINFO_FILE ?= "${IMAGE_ROOTFS}${IMAGE_BUILDINFO_FILE}"
 IMAGE_BUILDINFO_VARS := "DISTRO DISTRO_VERSION IMAGE_NAME"
 KERNELCONFIG_FILE ?= "${DEPLOY_DIR_IMAGE}/config_kernel"
 KCONFIGHARDENED_FILE = "${DEPLOY_DIR_IMAGE}/kernel-hardened-config.report"
-MANIFESTS_LIST ?= "IMAGE_MANIFEST CVE_CHECK_MANIFEST BUILDINFO_FILE KERNELCONFIG_FILE KCONFIGHARDENED_FILE SECCOMPILE_MANIFEST"
+
+MANIFESTS_LIST ?= "IMAGE_MANIFEST ${@'CVE_CHECK_MANIFEST' if not bb.utils.to_boolean(BB_NO_NETWORK) else ''} BUILDINFO_FILE KERNELCONFIG_FILE KCONFIGHARDENED_FILE SECCOMPILE_MANIFEST"
 
 # Enable PIE for glibc
 GLIBCPIE="--enable-static-pie"

--- a/classes/security/hardening.inc
+++ b/classes/security/hardening.inc
@@ -1,4 +1,5 @@
 # Copyright (C) 2022, RTE (http://www.rte-france.com)
+# Copyright (C) 2025 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 #
@@ -8,12 +9,15 @@
 #
 #
 
+BB_NO_NETWORK ??= "0"
+
 require hardening-handler.inc
 require hardening-config.inc
 
 # Community / 3rd-party classes to be included
-inherit cve-check
-include conf/distro/include/cve-extra-exclusions.inc
+
+inherit ${@'cve-check' if not bb.utils.to_boolean(BB_NO_NETWORK) else ''}
+include ${@'conf/distro/include/cve-extra-exclusions.inc' if not bb.utils.to_boolean(BB_NO_NETWORK) else ''}
 inherit image-buildinfo
 inherit create-spdx
 


### PR DESCRIPTION
The CVE check cannot be performed if the network is disabled. This patch adds support for the BB_NO_NETWORK variable to disable the CVE check when the network is disabled.