### PR TITLE
cukinia-tests: install bootloader hardening tests with seapath-security

### DIFF
--- a/recipes-cukinia-tests/cukinia-tests/cukinia-tests.bb
+++ b/recipes-cukinia-tests/cukinia-tests/cukinia-tests.bb
@@ -119,6 +119,9 @@ do_install () {
     install -m 0644 ${WORKDIR}/cukinia-update.conf ${D}${sysconfdir}/cukinia
     install_dir ${WORKDIR}/update_tests.d \
         ${D}${sysconfdir}/cukinia/update_tests.d
+    if ! ${@bb.utils.contains('DISTRO_FEATURES','seapath-security','true','false',d)}; then
+        rm ${D}${sysconfdir}/cukinia/update_tests.d/bootloader.conf
+    fi
     install -m 0644 ${WORKDIR}/configurations/cukinia-update.conf \
         ${D}${sysconfdir}/cukinia/configurations/cukinia-update.conf
 }


### PR DESCRIPTION
If seapath-security DISTRO_FEATURES is disabled:
* no grub password is set (grub-efi_%.bbappend)
* umask is not set to 027 by /etc/profile, and therefore /boot is not mounted with 0750 permissions (rootfs-tweaks.bbclass inherited by hardening.inc)

In that case, the bootloader.conf cukinia test file should not be installed. This commit handles this use case.