### PR TITLE
conf/distro/include/group.gid: passwd.uid: use same ceph UID and GID

### DIFF
--- a/conf/distro/include/group.gid
+++ b/conf/distro/include/group.gid
@@ -53,10 +53,10 @@ systemd-resolve:x:986:
 systemd-network:x:987:
 systemd-journal:x:988:
 openvswitch:x:989:
-ceph:x:990:
+hugepages:x:990:openvswitch
 snmp:x:991:
 vfio-net:x:993:openvswitch
-hugepages:x:994:openvswitch
+ceph:x:994:
 sshd:x:995:
 haclient:x:996:livemigration
 messagebus:x:997:

--- a/conf/distro/include/passwd.uid
+++ b/conf/distro/include/passwd.uid
@@ -25,7 +25,7 @@ systemd-timesync:x:990:985::/:/sbin/nologin
 systemd-resolve:x:991:986::/:/sbin/nologin
 systemd-network:x:992:987::/:/sbin/nologin
 openvswitch:x:993:989::/home/openvswitch:/bin/sh
-ceph:x:994:990:Ceph daemons:/var/lib/ceph:/bin/nologin
+ceph:x:994:994:Ceph daemons:/var/lib/ceph:/bin/nologin
 snmp:x:995:991:SNMP server daemon:/var/lib/snmp:/sbin/nologin
 sshd:x:997:995::/var/run/sshd:/bin/false
 hacluster:x:998:996:cluster user:/var/lib/heartbeat/cores/hacluster:/usr/sbin/nologin


### PR DESCRIPTION
ceph-ansible playbooks, which are currently used for ceph configuration, expect that the ceph UID and GID have the same value. Therefore, switch hugepages and ceph group GIDs so that ceph UID and GID use the same value.

Fixes partially https://github.com/seapath/ansible/issues/695