### PR TITLE
python3-requests: backport to 2.31.0

### DIFF
--- a/conf/distro/seapath-common.inc
+++ b/conf/distro/seapath-common.inc
@@ -106,3 +106,4 @@ USERADD_GID_TABLES = "conf/distro/include/group.gid"
 # So we need to use a earlier version
 REQUIRED_VERSION_rocksdb = "6.20.%"
 REQUIRED_VERSION_python3-cython = "0.29.%"
+REQUIRED_VERSION_python3-requests = "2.31.0"

--- a/recipes-seapath/python3-requests/python3-requests_2.31.0.bb
+++ b/recipes-seapath/python3-requests/python3-requests_2.31.0.bb
@@ -1,0 +1,24 @@
+SUMMARY = "Python HTTP for Humans."
+HOMEPAGE = "https://requests.readthedocs.io"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=34400b68072d710fecd0a2940a0d1658"
+
+SRC_URI[sha256sum] = "942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"
+
+inherit pypi python_setuptools_build_meta
+
+RDEPENDS:${PN} += " \
+    python3-certifi \
+    python3-email \
+    python3-json \
+    python3-netserver \
+    python3-pysocks \
+    python3-urllib3 \
+    python3-chardet \
+    python3-idna \
+    python3-compression \
+"
+
+CVE_PRODUCT = "requests"
+
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
Currently, python3-requests is provided by Scarthgap in v2.32.0. Unforunately, this version is not compatible with Ansible Docker module, as it generates the following exception:
```Error connecting:
Error while fetching server API version: Not supported URL scheme
http+docker```

The solution, provided by [1], is to use a lower version, v2.31.0.

[1]: https://github.com/geerlingguy/ansible-role-docker/issues/462
Signed-off-by: Paul Le Guen de Kerneizon <paul.leguendekerneizon@savoirfairelinux.com>