### PR TITLE
images: install rsync in all SEAPATH images

### DIFF
--- a/recipes-core/images/seapath-common.inc
+++ b/recipes-core/images/seapath-common.inc
@@ -25,6 +25,7 @@ IMAGE_INSTALL:append = " \
     python3-modules \
     python3-requests \
     python3-setuptools \
+    rsync \
 "
 
 IMAGE_INSTALL:append = " less"

--- a/recipes-core/images/seapath-guest-common.inc
+++ b/recipes-core/images/seapath-guest-common.inc
@@ -16,7 +16,6 @@ IMAGE_INSTALL:append = " \
     net-snmp-server \
     net-snmp-client \
     net-snmp-configuration \
-    rsync \
 "
 #add docker
 IMAGE_INSTALL += " \


### PR DESCRIPTION
rsync package is used by Ansible `synchronize` module, and so can be used on any SEAPATH machines.