### PR TITLE
images: install rsync in all SEAPATH images

### DIFF
--- a/recipes-core/images/seapath-common.inc
+++ b/recipes-core/images/seapath-common.inc
@@ -24,6 +24,7 @@ IMAGE_INSTALL:append = " \
     python3-json \
     python3-modules \
     python3-requests \
+    rsync \
 "
 
 IMAGE_INSTALL:append = " less"


### PR DESCRIPTION
This commit is a backport from scarthgap branch.

Original commit message:
rsync package is used by Ansible `synchronize` module, and so can be used on any SEAPATH machines.