### PR TITLE
images: conditional inclusion of clustering cockpit packages

### DIFF
--- a/recipes-core/images/seapath-test-common.inc
+++ b/recipes-core/images/seapath-test-common.inc
@@ -1,5 +1,5 @@
 # Copyright (C) 2021, RTE (http://www.rte-france.com)
-# Copyright (C) 2024 Savoir-faire Linux, Inc.
+# Copyright (C) 2024-2025 Savoir-faire Linux, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 require seapath-host-common.inc
@@ -8,8 +8,8 @@ require seapath-host-common.inc
 IMAGE_INSTALL:append = " \
     cockpit \
     cockpit-bridge \
-    cockpit-cluster-dashboard \
-    cockpit-cluster-vm-management \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'seapath-clustering', 'cockpit-cluster-dashboard', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'seapath-clustering', 'cockpit-cluster-vm-management', '', d)} \
     cockpit-dashboard \
     cockpit-machines \
     cockpit-shell \


### PR DESCRIPTION
When the 'seapath-clustering' feature is enabled in DISTRO_FEATURES, include the 'cockpit-cluster-dashboard' and
'cockpit-cluster-vm-management' packages in test images.