### PR TITLE
wic/mkefidisk: use 4096 block size for persistent

### DIFF
--- a/wic/mkefidisk.wks.in
+++ b/wic/mkefidisk.wks.in
@@ -12,4 +12,4 @@ part /boot --ondisk sda --label efi1 --active --align 1024  --part-type C12A7328
 part / --source rootfs --exclude-path boot/ --ondisk sda --fstype=ext4 --label rootfs0 --align 1024 --size 8G
 part / --ondisk sda --fstype=ext4 --label rootfs1 --align 1024 --size 8G
 part /var/log --size 4096 --ondisk sda --fstype=ext4 --label log --align 1024 --use-label
-part /mnt/persistent --size 256 --ondisk sda --fstype=ext4 --label persistent --align 1024
+part /mnt/persistent --size 256 --ondisk sda --fstype=ext4 --label persistent --align 4096


### PR DESCRIPTION
Currently, we use a block size of 1024 bytes for the persistent partition. As a consequence, when resizing the partition on a large disk (> 1TB), too many block group descriptors are created resulting the following error by resize2fs:

```
resize2fs: New size results in too many block group descriptors
```

resize2fs maintainers [1] suggest to increase logical block size to 4KB to fix this error.

[1]: https://github.com/tytso/e2fsprogs/issues/50#issuecomment-702818715