### PR TITLE
distro: add seapath-cockpit DISTRO_FEATURES

### DIFF
--- a/conf/distro/seapath-common.inc
+++ b/conf/distro/seapath-common.inc
@@ -75,6 +75,9 @@ DISTRO_FEATURES:append = " seapath-overlay"
 # Enable clustering
 DISTRO_FEATURES:append = " seapath-clustering"
 
+# Enable Cockpit Web UI if defined in seapath.conf
+DISTRO_FEATURES:append = "${@bb.utils.contains('SEAPATH_COCKPIT', 'true', ' seapath-cockpit', '', d)}"
+
 # Set persistent /var/log
 VOLATILE_LOG_DIR = "no"
 

--- a/recipes-core/images/seapath-host-common.inc
+++ b/recipes-core/images/seapath-host-common.inc
@@ -8,6 +8,23 @@ require ${@bb.utils.contains('DISTRO_FEATURES', 'seapath-clustering', 'seapath-h
 
 inherit ${@bb.utils.contains('DISTRO_FEATURES', 'seapath-security', 'security/qa-host-images', '', d)}
 
+# Cockpit web GUI
+COCKPIT_PACKAGES = " \
+    cockpit \
+    cockpit-bridge \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'seapath-clustering', 'cockpit-cluster-dashboard', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'seapath-clustering', 'cockpit-cluster-vm-management', '', d)} \
+    cockpit-dashboard \
+    cockpit-machines \
+    cockpit-shell \
+    cockpit-systemd \
+    cockpit-update \
+    cockpit-users \
+    cockpit-ws \
+"
+
+IMAGE_INSTALL:append = "${@bb.utils.contains('DISTRO_FEATURES', 'seapath-cockpit', ' ${COCKPIT_PACKAGES}', '', d)}"
+
 # Hypervisor and cluster tests
 IMAGE_INSTALL:append = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'seapath-clustering', 'cukinia-tests-cluster', '', d)} \

--- a/recipes-core/images/seapath-test-common.inc
+++ b/recipes-core/images/seapath-test-common.inc
@@ -4,19 +4,7 @@
 
 require seapath-host-common.inc
 
-# Cockpit web GUI
 IMAGE_INSTALL:append = " \
-    cockpit \
-    cockpit-bridge \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'seapath-clustering', 'cockpit-cluster-dashboard', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'seapath-clustering', 'cockpit-cluster-vm-management', '', d)} \
-    cockpit-dashboard \
-    cockpit-machines \
-    cockpit-shell \
-    cockpit-systemd \
-    cockpit-update \
-    cockpit-users \
-    cockpit-ws \
     ethtool \
     rt-tests \
 "


### PR DESCRIPTION
Currently, Cockpit is only enabled when using a SEAPATH test image. However we might want it to use on other images.
This commit adds a new distro feature `seapath-cockpit` which can be enabled from the seapath.conf file using the SEAPATH-COCKPIT variable. When enabled, it installs the cockpit packages on the target image.