### PR TITLE
Fix systemctl cmd in cukinia tests for auditd

### DIFF
--- a/recipes-cukinia-tests/cukinia-tests/files/hypervisor_tests.d/auditd.conf
+++ b/recipes-cukinia-tests/cukinia-tests/files/hypervisor_tests.d/auditd.conf
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cukinia_log "$(_colorize yellow "--- Check auditd ---")"
-id "SEAPATH-00027" as "auditd is inactive" not cukinia_cmd systemctl --is-active --quiet auditd
+id "SEAPATH-00027" as "auditd is inactive" not cukinia_cmd systemctl is-active --quiet auditd


### PR DESCRIPTION
Fix systemctl command because is-active is a subcommand of systemctl, thus putting -- before it is invalid.