### PR TITLE
layer: disable ceph from meta-virtualization

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -22,3 +22,5 @@ BBFILE_PRIORITY_meta-seapath = "20"
 
 LAYERSERIES_COMPAT_meta-seapath = "scarthgap"
 LAYERDEPENDS_meta-seapath = "efi-secure-boot"
+
+BBMASK += "${LAYERDIR}/../meta-virtualization/recipes-extended/ceph"


### PR DESCRIPTION
To avoid conflicts with our own ceph recipes, we disable the ceph recipes from the meta-virtualization layer by adding a BBMASK entry in our layer.conf.