### PR TITLE
wic/mkefidisk-guest.wks: increase rootfs size to 10 Gb

### DIFF
--- a/wic/mkefidisk-guest.wks.in
+++ b/wic/mkefidisk-guest.wks.in
@@ -8,7 +8,6 @@
 bootloader --ptable gpt
 
 part /boot --source rootfs --rootfs-dir=${IMAGE_ROOTFS}/boot --ondisk sda --label efi --active --align 1024  --part-type C12A7328-F81F-11D2-BA4B-00A0C93EC93B --size 128M --use-uuid
-part / --source rootfs --exclude-path boot/ --ondisk sda --fstype=ext4 --label platform --align 1024 --use-uuid --size 2G
+part / --source rootfs --exclude-path boot/ --ondisk sda --fstype=ext4 --label platform --align 1024 --use-uuid --size 10G
 part /var/log --size 4096 --ondisk sda --fstype=ext4 --label log --align 1024
 part /var/data --size 1024 --ondisk sda --fstype=ext4 --label data --align 1024
-


### PR DESCRIPTION
The previous size left in practice roughly 1.5 Gb of free space on the VM disk for tests and applications. This might not be sufficient for all use case, such as long IEC 61850 latency tests which may needs multiple gigabytes of space to store SV timestamp data.