### PR TITLE
cukinia-tests: fix IOMMU mode test

### DIFF
--- a/recipes-cukinia-tests/cukinia-tests/files/hypervisor_tests.d/iommu.conf
+++ b/recipes-cukinia-tests/cukinia-tests/files/hypervisor_tests.d/iommu.conf
@@ -4,7 +4,7 @@
 cukinia_log "$(_colorize yellow "--- Check iommu status ---")"
 
 # Check that IOMMU is in passthrough mode (best performance, less security)
-id "SEAPATH-00030" as "iommu enabled in PASSTHROUGH mode" cukinia_kconf CONFIG_IOMMU_DEFAULT_PASSTHROUGH y
+id "SEAPATH-00030" as "iommu enabled in PASSTHROUGH mode" cukinia_kconf IOMMU_DEFAULT_PASSTHROUGH y
 
 # Check that iommu is loaded in system
 id "SEAPATH-00031" as "iommu is loaded" cukinia_cmd find /sys/class/iommu/*


### PR DESCRIPTION
cukinia_kconf automatically appends the "CONFIG_" prefix, therefore it shouldn't be given in parameter.