### PR TITLE
system-config: predictable network interface names for USB interfaces

### DIFF
--- a/recipes-seapath/system-config/system-config.bb
+++ b/recipes-seapath/system-config/system-config.bb
@@ -13,6 +13,7 @@ RDEPENDS:${PN}-ovs = "python3-setup-ovs openvswitch"
 SRC_URI = " \
     file://common/10-erspan0.network \
     file://common/10-gretap0.network \
+    file://common/73-usb-net-by-mac.link \
     file://common/90-sysctl-hardening.conf \
     file://common/99-sysctl-network.conf \
     file://common/terminal_idle.sh \
@@ -79,6 +80,8 @@ do_install () {
         ${D}${systemd_unitdir}/network
     install -m 0644 ${WORKDIR}/common/10-gretap0.network \
         ${D}${systemd_unitdir}/network
+    install -m 0644 ${WORKDIR}/common/73-usb-net-by-mac.link \
+        ${D}${systemd_unitdir}/link
 
 # OpenVSwitch
     install -m 0644 ${WORKDIR}/ovs/openvswitch.conf \
@@ -133,6 +136,7 @@ FILES:${PN}-common = " \
     ${systemd_unitdir}/system/var-log.mount \
     ${systemd_unitdir}/network/10-erspan0.network \
     ${systemd_unitdir}/network/10-gretap0.network \
+    ${systemd_unitdir}/link/73-usb-net-by-mac.link \
 "
 
 FILES:${PN}-keymap = " \

--- a/recipes-seapath/system-config/system-config/common/73-usb-net-by-mac.link
+++ b/recipes-seapath/system-config/system-config/common/73-usb-net-by-mac.link
@@ -1,0 +1,6 @@
+[Match]
+Path=*-usb-*
+
+[Link]
+NamePolicy=mac
+AlternativeNamesPolicy=path


### PR DESCRIPTION
As it is done on Debian and Ubuntu, we want to have predictable network interface names for USB interfaces. This is done by adding a .link file in /etc/systemd/network/ that matches on the USB path and sets the NamePolicy to mac.

We keep the existing names as alternative names, so that the old names are still available as aliases. This way, we can transition to the new naming scheme without breaking existing scripts and configurations that rely on the old names.