### PR TITLE
crmsh: create /var/log/crmsh/crmsh.log at boot via systemd-tmpfiles

### DIFF
--- a/recipes-cgl/crmsh/crmsh_%.bbappend
+++ b/recipes-cgl/crmsh/crmsh_%.bbappend
@@ -1,0 +1,9 @@
+# Copyright (C) 2026 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+do_install:append() {
+    install -d ${D}${sysconfdir}/tmpfiles.d
+    echo "f /var/log/crmsh/crmsh.log 0664 hacluster haclient -" > ${D}${sysconfdir}/tmpfiles.d/crmsh-log.conf
+}
+
+FILES:${PN} += "${sysconfdir}/tmpfiles.d/crmsh-log.conf"


### PR DESCRIPTION
Add a systemd-tmpfiles configuration entry to create the crmsh log file at boot with appropriate permissions (0664 hacluster:haclient). The upstream crmsh package already creates the parent directory via its own tmpfiles config, but the log file itself was only created on first run. This ensures the file exists from boot time.