### PR TITLE
hardening: embed CVE statuses in the SPDX3 file

### DIFF
--- a/classes/security/hardening.inc
+++ b/classes/security/hardening.inc
@@ -20,7 +20,9 @@ include conf/distro/include/cve-extra-exclusions.inc
 inherit image-buildinfo
 
 inherit create-spdx
-inherit vex
+
+# We want the CVE statuses in the SPDX3 file:
+SPDX_INCLUDE_VEX = "all"
 
 SPDX_PRETTY = "1"
 SPDX_INCLUDE_SOURCES = "0"


### PR DESCRIPTION
Starting with Yocto 5.3, it is possible to embed the VEX annotations in the SPDX3 file.
After turning on this option, we don't need to export OpenVEX files anymore.