### PR TITLE
cephadm: depend on the sudo recipe for useradd

### DIFF
--- a/recipes-extended/ceph/cephadm.inc
+++ b/recipes-extended/ceph/cephadm.inc
@@ -16,6 +16,8 @@ GROUPADD_PARAM:${CEPHADM_PACKAGE} = "\
     --force --system --gid 168 cephadm ; \
     --force --system --gid 167 containerized-ceph"
 
+USERADD_DEPENDS = "sudo"
+
 USERADD_PARAM:${CEPHADM_PACKAGE} = "\
     --system \
     --create-home \


### PR DESCRIPTION
The `$SUDO_GROUP_OWNER` group is created by the `sudo` recipe but the dependency was not explicitely set in the cephadm recipe.
This fixes the `useradd: group 'privileged' does not exist` error appearing randomly when compiling ceph.