### PR TITLE
conf/distro/seapath-common.inc: add rm_work inheritance

### DIFF
--- a/conf/distro/seapath-common.inc
+++ b/conf/distro/seapath-common.inc
@@ -92,6 +92,10 @@ INHERIT += "security/hardening"
 INHERIT += "security/readonly"
 INHERIT += "overlay"
 
+# Remove recipe work directories after build to save disk space.
+# Set SEAPATH_RM_WORK to true in seapath.conf to enable.
+INHERIT += "${@'rm_work' if (d.getVar('SEAPATH_RM_WORK') or 'false') == 'true' else ''}"
+
 IMAGE_FEATURES[validitems] += "unsafe-pam-policy"
 
 # Set version of ceph to 16.x.y


### PR DESCRIPTION
Add conditional inheritance of the rm_work class based on the SEAPATH_RM_WORK variable from seapath.conf. This allows removing recipe work directories after build to save disk space.