### PR TITLE
images: seapath-guest-common: seapath-host-common: remove podman-compose

### DIFF
--- a/recipes-core/images/seapath-guest-common.inc
+++ b/recipes-core/images/seapath-guest-common.inc
@@ -18,7 +18,7 @@ IMAGE_INSTALL:append = " \
     net-snmp-configuration \
 "
 #add podman
-IMAGE_INSTALL += "podman podman-compose"
+IMAGE_INSTALL += "podman"
 
 IMAGE_FSTYPES = "wic.qcow2 wic.vmdk"
 WKS_FILE = "mkefidisk-guest.wks.in"

--- a/recipes-core/images/seapath-host-common.inc
+++ b/recipes-core/images/seapath-host-common.inc
@@ -33,7 +33,7 @@ IMAGE_INSTALL:append = " \
 "
 
 # Pomdan
-IMAGE_INSTALL += "podman podman-compose"
+IMAGE_INSTALL += "podman"
 
 # Host images are compatible with seapath-hypervisor only
 # GRUB static configuration for host machines


### PR DESCRIPTION
SEAPATH relies on systemd Quadlets, a podman built-in feature, to manage multiple containers management rather than podman-compose [1]. Moreover, SEAPATH Debian doesn't package podman-compose.

Therefore, remove it from the SEAPATH Yocto images as not used by SEAPATH.

[1]: https://lf-energy.atlassian.net/wiki/spaces/SEAP/pages/437289031/Deploying+containers