### PR TITLE
linux-mainline-rt: use kernel/git/stable/linux.git as reference for 6.12

### DIFF
--- a/recipes-kernel/linux/linux-mainline-rt_6.12.bb
+++ b/recipes-kernel/linux/linux-mainline-rt_6.12.bb
@@ -9,17 +9,16 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/linux-mainline-rt_6.12:"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 LINUX_MAJOR_VERSION = "6.12"
-LINUX_REVISION_VERSION = "89"
+LINUX_REVISION_VERSION = "95"
 LINUX_VERSION = "${LINUX_MAJOR_VERSION}.${LINUX_REVISION_VERSION}"
-RT_REVISION = "rt18"
-KBRANCH = "v${LINUX_MAJOR_VERSION}-rt"
-LINUX_FULL_VERSION = "${LINUX_VERSION}-${RT_REVISION}"
+KBRANCH = "linux-${LINUX_MAJOR_VERSION}.y"
+LINUX_FULL_VERSION = "${LINUX_VERSION}"
 KTAG = "v${LINUX_FULL_VERSION}"
 PV = "${LINUX_FULL_VERSION}+git${SRCPV}"
 
-SRCREV = "fa86ec894b58dec08703af4a28eb27ccb5d4ecfb"
+SRCREV = "296aabce459470a4c1b68ffd0c0c0920e563aaad"
 
-SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/rt/linux-stable-rt.git;protocol=https;name=machine;branch=${KBRANCH} \
+SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git;protocol=https;name=machine;branch=${KBRANCH} \
         file://defconfig \
         file://megaraid.cfg \
         file://gcc-plugin.cfg \


### PR DESCRIPTION
The RT patch has been fully merged in 6.12. There is no "-rt" revision for this version since 6.12.89-rt89.

Change to use the stable repository and bump the version to the latest 6.12 revision (6.12.95).