### PR TITLE
linux-mainline-rt: use kernel class source directory

### DIFF
--- a/recipes-kernel/linux/linux-mainline-rt.inc
+++ b/recipes-kernel/linux/linux-mainline-rt.inc
@@ -34,8 +34,6 @@ inherit kernel-yocto
 
 LINUX_VERSION_EXTENSION:append = "-mainline-rt"
 
-S = "${WORKDIR}/git"
-
 COMPATIBLE_MACHINE = "(seapath|seapath-no-iommu)"
 
 CVE_VERSION = "${LINUX_VERSION}"


### PR DESCRIPTION
Let kernel.bbclass use its default S value, STAGING_KERNEL_DIR.

Overriding S with WORKDIR/git separates the checked-out kernel sources from kernel-source. As a result, make-mod-scripts cannot find the kernel Makefile in STAGING_KERNEL_DIR.

Remove the override, so the kernel sources are staged where dependent recipes expect them.
