### PR TITLE
ci: attach delegation check to the PR head sha

### DIFF
--- a/.github/workflows/pr-delegation.yml
+++ b/.github/workflows/pr-delegation.yml
@@ -43,6 +43,9 @@ jobs:
         id: pr-metadata
         run: |
           echo "number=$(cat "${{ env.PR_METADATA_FILE }}" | jq -r '.pr_number')" >> "$GITHUB_OUTPUT"
+          # The check must be attached to the PR head (not the merge commit)
+          # so it shows up on the PR and can gate the merge.
+          echo "head_sha=$(cat "${{ env.PR_METADATA_FILE }}" | jq -r '.pr_head_sha')" >> "$GITHUB_OUTPUT"
           echo "sha=$(cat "${{ env.PR_METADATA_FILE }}" | jq -r '.pr_sha')" >> "$GITHUB_OUTPUT"
           echo "base_ref=$(cat "${{ env.PR_METADATA_FILE }}" | jq -r '.pr_base_ref')" >> "$GITHUB_OUTPUT"
 
@@ -54,7 +57,7 @@ jobs:
         with:
           token: "${{ github.token }}"
           name: "PR workflow on the main repository"
-          sha: "${{ steps.pr-metadata.outputs.sha }}"
+          sha: "${{ steps.pr-metadata.outputs.head_sha }}"
           status: "in_progress"
           details_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           output: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,8 +18,6 @@ on:
       - opened
       - synchronize
       - reopened
-    paths-ignore:
-      - .github/**/*
 
 jobs:
   # It can look crazy but the workflow_run trigger does not expose data about

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -38,6 +38,7 @@ jobs:
           cat <<EOF > ${{ env.PR_METADATA_FILE }}
           {
             "pr_number": ${{ github.event.pull_request.number }},
+            "pr_head_sha": "${{ github.event.pull_request.head.sha }}",
             "pr_sha": "${{ github.sha }}",
             "pr_base_ref": "${{ github.base_ref }}"
           }


### PR DESCRIPTION
The 'PR workflow on the main repository' check was created on the auto-generated merge commit (`refs/pull/N/merge`) because `pr.yml` used `${{ github.sha }}`, which for a `pull_request` event is the merge commit, not the PR head. As a result the check never attached to the PR head commit: it did not show up on the PR and could not gate the merge.

This change exports the PR head sha (`github.event.pull_request.head.sha`) and creates the check on it, while keeping the build dispatch's `origin_sha` on the merge commit so fork-PR checkout in the main repository still works.

The PR also revert commit 3c765e81dc6edfbfcf39f6bacbbdd577485d00ee ("don't trigger CI for CI-related changes") because all workflows need to pass to allow a PR merging.